### PR TITLE
Android module automatic link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,23 @@ Lets create a simple app that integrates `PSPDFKit.framework` and uses the `reac
 1. Make sure `react-native-cli` is installed: `yarn global add react-native-cli`
 2. Create the app with `react-native init YourApp`.
 3. Step into your newly created app folder: `cd YourApp`
-4. Install `react-native-pspdfkit` from GitHub: `react-native install github:PSPDFKit/react-native`
-5. Create the folder `ios/PSPDFKit` and copy `PSPDFKit.framework` into it.
-6. Open `ios/YourApp.xcodeproj` in Xcode: `open ios/YourApp.xcodeproj`
-7. Make sure the deployment target is set to 9.0 or higher:
+4. Install `react-native-pspdfkit` from GitHub: `yarn add github:PSPDFKit/react-native`
+5. Link module `react-native-pspdfkit`: `react-native link react-native-pspdfkit` 
+6. Create the folder `ios/PSPDFKit` and copy `PSPDFKit.framework` into it.
+7. Open `ios/YourApp.xcodeproj` in Xcode: `open ios/YourApp.xcodeproj`
+8. Make sure the deployment target is set to 9.0 or higher:
 ![Deployment Target](screenshots/deployment-target.png)
-8. Change "View controller-based status bar appearance" to `YES` in `Info.plist`:
+9. Change "View controller-based status bar appearance" to `YES` in `Info.plist`:
 ![View Controller-Based Status Bar Appearance](screenshots/view-controller-based-status-bar-appearance.png)
-9. Open `node_modules/react-native-pspdfkit/ios` and drag and drop `RCTPSPDFKit.xcodproj` into the YourApp Xcode project:
+10. Open `node_modules/react-native-pspdfkit/ios` and drag and drop `RCTPSPDFKit.xcodproj` into the YourApp Xcode project:
 ![Project Dependency](screenshots/project-dependency.png)
-10. Link with the `libRCTPSPDFKit.a` static library:
+11. Link with the `libRCTPSPDFKit.a` static library:
 ![Linking Static Library](screenshots/linking-static-library.png)
-11. Embed `PSPDFKit.framework` by drag and dropping it into the "Embedded Binaries" section of the "YourApp" target (Select "Create groups"). This will also add it to the "Linked Framworks and Libraries" section:
+12. Embed `PSPDFKit.framework` by drag and dropping it into the "Embedded Binaries" section of the "YourApp" target (Select "Create groups"). This will also add it to the "Linked Framworks and Libraries" section:
 ![Embedding PSPDFKit](screenshots/embedding-pspdfkit.png)
-12. Add a PDF by drag and dropping it into your Xcode project (Select "Create groups" and add to target "YourApp"). This will add the document to the "Copy Bundle Resources" build phase:
+13. Add a PDF by drag and dropping it into your Xcode project (Select "Create groups" and add to target "YourApp"). This will add the document to the "Copy Bundle Resources" build phase:
 ![Adding PDF](screenshots/adding-pdf.png)
-13. Replace the default component from `index.ios.js` with a simple touch area to present the bundled PDF:
+14. Replace the default component from `index.ios.js` with a simple touch area to present the bundled PDF:
 
 ```javascript
 import React, { Component } from 'react';
@@ -120,8 +121,9 @@ Let's create a simple app that integrates `pspdfkit-*.aar` and uses the react-na
 1. Make sure `react-native-cli` is installed: `yarn global add react-native-cli`
 2. Create the app with `react-native init YourApp`.
 3. Step into your newly created app folder: `cd YourApp`.
-4. Install `react-native-pspdfkit` from GitHub: `react-native install github:PSPDFKit/react-native`.
-5. Add dependencies to `YourApp/node_modules/react-native-pspdfkit/android/build.gradle`.
+4. Install `react-native-pspdfkit` from GitHub: `yarn add github:PSPDFKit/react-native`.
+5. Link module `react-native-pspdfkit`: `react-native link react-native-pspdfkit`. 
+6. Add dependencies to `YourApp/node_modules/react-native-pspdfkit/android/build.gradle`.
    
     A complete list of the dependencies needed can be found in the [documentation](https://pspdfkit.com/guides/android/current/getting-started/integrating-pspdfkit/#toc_manual-library-file-integration) step 6, under `Manual library file integration`.
 For PSPDFKit 2.9.3 :
@@ -141,30 +143,27 @@ dependencies {
 	}
   ```
 
-6. Add the following lines to `YourApp/android/settings.gradle` file:
+7. Add the following lines to `YourApp/android/settings.gradle` file:
 
   ```   
 include ':pspdfkit-lib'
-include ':react-native-pspdfkit'
-project(':react-native-pspdfkit').projectDir = new File(settingsDir, '../node_modules/react-native-pspdfkit/android')
   ```
         
-7. Create new `pspdfkit-lib` folder in `YourApp/android`.
-8. Create new `build.gradle` file in `YourApp/android/pspdfkit-lib` and add the following lines:
+8. Create new `pspdfkit-lib` folder in `YourApp/android`.
+9. Create new `build.gradle` file in `YourApp/android/pspdfkit-lib` and add the following lines:
      
   ```  
 configurations.maybeCreate("default")
-def library =  fileTree(".").filter { it.isFile()}.filter {it.name.endsWith('.aar')}.files.name.first()
+def library =  fileTree(".").filter { it.isFile() }.filter { it.name.endsWith('.aar') }.files.name.first()
 artifacts.add("default", file(library))
   ```
         
-9. Copy `pspdfkit-*.aar` library in `YourApp/android/pspdfkit-lib`.
-10. Add the following dependencies to `YourApp/android/app/build.gradle` file:
+10. Copy `pspdfkit-*.aar` library in `YourApp/android/pspdfkit-lib`.
+11. Add the following dependencies to `YourApp/android/app/build.gradle` file:
      
    ```
    dependencies {
        ...
-       compile project(':react-native-pspdfkit')
        compile project(':pspdfkit-lib')
    }
    ```  
@@ -192,38 +191,6 @@ artifacts.add("default", file(library))
    }
    ...
    ```
-        
-11. Add `PSPDFKitPackage` to `MainApplication.java` in `YourApp/android/app/src/main/java/com/yourapp` (note **two** places to edit):
-
-  ```diff
-package com.yourapp;
-
-import android.app.Application;
-
-import com.facebook.react.ReactApplication;
-import com.facebook.react.ReactNativeHost;
-import com.facebook.react.ReactPackage;
-import com.facebook.react.shell.MainReactPackage;
-import com.facebook.soloader.SoLoader;
-+ import com.pspdfkit.react.PSPDFKitPackage;
-.....
-public class MainApplication extends Application implements ReactApplication {
-  private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
-    @Override
-    public boolean getUseDeveloperSupport() {
-      return BuildConfig.DEBUG;
-    }   
-    @Override
-    protected List<ReactPackage> getPackages() {
-       return Arrays.<ReactPackage>asList(
-+          new PSPDFKitPackage(),
-               new MainReactPackage()
-        );
-    }
-  };
-  .....
-}
-  ```
      
 12. Set primary color. In `YourApp/android/app/src/main/res/values/styles.xml` replace
   ```xml    
@@ -234,81 +201,81 @@ with
 <item name="colorPrimary">#3C97C9</item>
   ```     
 13. Replace the default component from `YourApp/index.android.js` with a simple touch area to present a PDF document from the local device filesystem:
-
-  ```javascript
-	import React, { Component } from 'react';
-	import {
-	AppRegistry,
-	StyleSheet,
-	NativeModules,
-	Text,
-	TouchableHighlight,
-	View,
-	PermissionsAndroid
-	} from 'react-native';
+        
+   ```javascript
+   import React, { Component } from 'react';
+   import {
+     AppRegistry,
+     StyleSheet,
+     NativeModules,
+     Text,
+     TouchableHighlight,
+     View,
+     PermissionsAndroid
+   } from 'react-native';
 	
-	var PSPDFKit = NativeModules.PSPDFKit;
+   var PSPDFKit = NativeModules.PSPDFKit;
 	
-	const DOCUMENT = "file:///sdcard/document.pdf";
-	const LICENSE = "LICENSE_KEY_GOES_HERE";
-	const CONFIGURATION = {
-	  scrollContinuously : false,
-	  showPageNumberOverlay : true,
-	  pageScrollDirection : "vertical"
-	};
+   const DOCUMENT = "file:///sdcard/document.pdf";
+   const LICENSE = "LICENSE_KEY_GOES_HERE";
+   const CONFIGURATION = {
+     scrollContinuously : false,
+     showPageNumberOverlay : true,
+     pageScrollDirection : "vertical"
+   };
 	
-	PSPDFKit.setLicenseKey(LICENSE);
-	// Change 'YourApp' to your app's name.
-	class YourApp extends Component {
-	  _onPressButton() {
-	  requestExternalStoragePermission();
-	  }
-	
-	  render() {
-	    return (
-	      <View style={styles.container}>
-	        <Text>{PSPDFKit.versionString}</Text>
-	          <TouchableHighlight onPress={this._onPressButton}>
-	            <Text style={styles.text}>Tap to Open Document</Text>
-	            </TouchableHighlight>
-	      </View>
-	    );
-	  }
-	}
-	
-	async function requestExternalStoragePermission() {
-	  try {
-	    const granted = await PermissionsAndroid.request(
-	      PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE
-	    )
-	    if (granted === PermissionsAndroid.RESULTS.GRANTED) {
-	      console.log("Write external storage permission granted")
-	      PSPDFKit.present(DOCUMENT, CONFIGURATION);
-	    } else {
-	      console.log("Write external storage permission denied")
-	    }
-	  } catch (err) {
-	    console.warn(err)
-	  }
-	}
-	
-	const styles = StyleSheet.create({
-	  container: {
-	    flex: 1,
-	    justifyContent: 'center',
-	    alignItems: 'center',
-	    backgroundColor: '#F5FCFF',
-	  },
-	  text: {
-	    fontSize: 20,
-	    textAlign: 'center',
-	    margin: 10,
-	  }
-	});
-	
-	// Change both 'YourApp's to your app's name.
-	AppRegistry.registerComponent('YourApp', () => YourApp);
-  ```  
+   PSPDFKit.setLicenseKey(LICENSE);
+   // Change 'YourApp' to your app's name.
+   class YourApp extends Component {
+     _onPressButton() {
+     requestExternalStoragePermission();
+     }
+        
+     render() {
+       return (
+         <View style={styles.container}>
+           <Text>{PSPDFKit.versionString}</Text>
+             <TouchableHighlight onPress={this._onPressButton}>
+               <Text style={styles.text}>Tap to Open Document</Text>
+               </TouchableHighlight>
+         </View>
+       );
+     }
+   }
+        
+   async function requestExternalStoragePermission() {
+     try {
+       const granted = await PermissionsAndroid.request(
+         PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE
+       )
+       if (granted === PermissionsAndroid.RESULTS.GRANTED) {
+         console.log("Write external storage permission granted")
+         PSPDFKit.present(DOCUMENT, CONFIGURATION);
+       } else {
+         console.log("Write external storage permission denied")
+       }
+     } catch (err) {
+       console.warn(err)
+     }
+   }
+        
+   const styles = StyleSheet.create({
+     container: {
+       flex: 1,
+       justifyContent: 'center',
+       alignItems: 'center',
+       backgroundColor: '#F5FCFF',
+     },
+     text: {
+       fontSize: 20,
+       textAlign: 'center',
+       margin: 10,
+     }
+   });
+        
+   // Change both 'YourApp's to your app's name.
+   AppRegistry.registerComponent('YourApp', () => YourApp);
+   ```  
 14. Before launching the app you need to copy a PDF document onto your development device or emulator.
 
 	```bash


### PR DESCRIPTION
## Resolves #6 

Instead of type
 `react-native install github:PSPDFKit/react-native`

Use
`npm install github:PSPDFKit/react-native -—save`
`react-native link react-native-pspdfkit`

This will also add the dependencies to our Gradle files, simplifying the installation steps.