### PR TITLE
Fix sample app for new PSPDFKit 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,6 @@ with
    var PSPDFKit = NativeModules.PSPDFKit;
 	
    const DOCUMENT = "file:///sdcard/document.pdf";
-   const LICENSE = "LICENSE_KEY_GOES_HERE";
    const CONFIGURATION = {
      scrollContinuously : false,
      showPageNumberOverlay : true,

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
 
     <application>
     <activity
-        android:name="com.pspdfkit.ui.PSPDFActivity"
+        android:name="com.pspdfkit.ui.PdfActivity"
         android:windowSoftInputMode="adjustNothing" />
     </application>
 </manifest>


### PR DESCRIPTION
- Rename `PSPDFActivity` to `PdfActivity` in Android manifest file
- Remove unused constant `LICENSE` from example file `index.android.js` in README