### PR TITLE
Use 'com.pspdfkit:pspdfkit-demo'

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,10 @@
+/**
+*   Contains gradle configuration constants
+*/
+ext {
+    PSPDFKIT_VERSION = '3.0.0'
+}
+
 buildscript {
     repositories {
         jcenter()
@@ -25,7 +32,38 @@ android {
     }
 }
 
+def demoVersion = false;
+project.repositories.each {
+    if (it instanceof MavenArtifactRepository) {
+        if ("$it.url".contains("customers.pspdfkit.com/maven")) {
+            // Bug: https://github.com/gradle/gradle/issues/1230
+            def username = it.credentials.username
+            def password = it.credentials.password
+
+            if (username == "pspdfkit") {
+                if (password != null && password.startsWith("TRIAL")) {
+                    demoVersion = true;
+                } else if (password != null && password == "YOUR_MAVEN_PASSWORD_GOES_HERE") {
+                    println "#######################################################################################################"
+                    println "### Credentials error: edit 'YourApp/android/build.gradle' file and modify PSPDFKit maven password. ###"
+                    println "#######################################################################################################"
+                }
+            }
+        }
+    }
+}
+
+if (demoVersion) {
+    println "##############################"
+    println "### PSPDFKit Demo Version. ###"
+    println "##############################"
+}
+
 dependencies {
-    compile 'com.pspdfkit:pspdfkit:3.0.0'
-    compile 'com.facebook.react:react-native:+'
+    if (demoVersion) {
+        compile "com.pspdfkit:pspdfkit-demo:${PSPDFKIT_VERSION}"
+    } else {
+        compile "com.pspdfkit:pspdfkit:${PSPDFKIT_VERSION}"
+    }
+    compile "com.facebook.react:react-native:+"
 }


### PR DESCRIPTION
## Resolves #14

When password starts with TRIAL use 'com.pspdfkit:pspdfkit-demo'
dependency and log PSPDFKit demo version.

**Note**:  because of a [bug](https://github.com/gradle/gradle/issues/1230) in Gradle, the credentials cannot be compared directly otherwise an empty set of username and password will be added also to the local repo, and compilation will fail.