### PR TITLE
React Native update to 0.48.4 for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ PSPDFKit.present('document.pdf', {
 - Android Build Tools 23.0.1 (React Native)
 - Android Build Tools 25.0.2 (PSPDFKit module)
 - PSPDFKit >= 3.3.3
-- react-native >= 0.48.1
+- react-native >= 0.48.4
 
 #### Getting Started
 
@@ -194,7 +194,7 @@ with
   ```xml    
 <item name="colorPrimary">#3C97C9</item>
   ```     
-10. <a id="step-10"></a>Replace the default component from `YourApp/index.android.js` with a simple touch area to present a PDF document from the local device filesystem:
+10. <a id="step-10"></a>Replace the default component from `YourApp/App.js` with a simple touch area to present a PDF document from the local device filesystem:
         
    ```javascript
    import React, { Component } from 'react';
@@ -218,7 +218,7 @@ with
    };
 	
    // Change 'YourApp' to your app's name.
-   class YourApp extends Component {
+   export default class YourApp extends Component<{}> {
      _onPressButton() {
      requestExternalStoragePermission();
      }
@@ -264,9 +264,6 @@ with
        margin: 10,
      }
    });
-        
-   // Change both 'YourApp's to your app's name.
-   AppRegistry.registerComponent('YourApp', () => YourApp);
    ```  
 11. Before launching the app you need to copy a PDF document onto your development device or emulator.
 

--- a/samples/Catalog/index.android.js
+++ b/samples/Catalog/index.android.js
@@ -87,7 +87,7 @@ async function requestExternalStoragePermission(callback) {
   }
 }
 
-class Catalog extends Component {
+export default class Catalog extends Component<{}> {
   // Initialize the hardcoded data
   constructor(props) {
     super(props);

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start"

--- a/samples/Catalog/yarn.lock
+++ b/samples/Catalog/yarn.lock
@@ -2635,11 +2635,11 @@ react-devtools-core@^2.5.0:
     utf8 "^2.1.1"
 
 "react-native-pspdfkit@file:../../":
-  version "1.3.1"
+  version "1.5.0"
 
-react-native@0.48.1:
-  version "0.48.1"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.48.1.tgz#052ba5a86d3bdb748c288124248727d02b1c0939"
+react-native@0.48.4:
+  version "0.48.4"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.48.4.tgz#f305e9fef069a5b3f6a7250ddd50f603cf30ab2d"
   dependencies:
     absolute-path "^0.0.0"
     art "^0.10.0"


### PR DESCRIPTION
Update Catalog app for Android to React Native version `0.48.4`.
Update README.md using new syntax for main default class.
Version bump of Catalog app to `1.4.0`.