### PR TITLE
Add `additionalScrollViewFrameInsets` and `additionalContentInsets`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ See our [announcement blog post](https://pspdfkit.com/blog/2016/react-native-mod
 
 #### Requirements
 - Xcode 9
-- PSPDFKit >= 7.0.0
+- PSPDFKit >= 7.0.2
 - react-native >= 0.48.4
 
 #### Getting Started

--- a/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFConfiguration.m
+++ b/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFConfiguration.m
@@ -55,6 +55,8 @@
     SET(firstPageAlwaysSingle, BOOL)
     SET(spreadFitting, PSPDFConfigurationSpreadFitting)
     SET(clipToPageBoundaries, BOOL)
+    SET(additionalScrollViewFrameInsets, UIEdgeInsets)
+    SET(additionalContentInsets, UIEdgeInsets)
     SET(minimumZoomScale, float)
     SET(maximumZoomScale, float)
     SET(shadowEnabled, BOOL)

--- a/ios/cocoapods.md
+++ b/ios/cocoapods.md
@@ -4,7 +4,7 @@
 
 #### Requirements
 - Xcode 9
-- PSPDFKit >=7.0.0
+- PSPDFKit >=7.0.2
 - react-native >= 0.48.4
 - CocoaPods >= 1.3.1
 


### PR DESCRIPTION
⚠️ Do not merge! Requires PSPDFKit 7.0.2  ⚠️ 
---

# Details:

Add `additionalScrollViewFrameInsets` and `additionalContentInsets` from `PSPDFConfiguration` to easily adjust what used to be `margin` and `padding` in v6.

See: https://github.com/PSPDFKit/PSPDFKit/pull/12747

# Acceptance criteria

- [ ] Merge as soon as PSPDFKit 7.0.2 is released.