### PR TITLE
Add API to change pages programmatically

### DIFF
--- a/ios/RCTPSPDFKit/RCTPSPDFKitManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitManager.m
@@ -46,6 +46,16 @@ RCT_EXPORT_METHOD(dismiss) {
   [navigationController dismissViewControllerAnimated:true completion:nil];
 }
 
+RCT_EXPORT_METHOD(setPageIndex:(NSUInteger)pageIndex aniamted:(BOOL)animated) {
+  UIViewController *presentedViewController = RCTPresentedViewController();
+  NSAssert([presentedViewController isKindOfClass:UINavigationController.class], @"Presented view controller needs to be a UINavigationController");
+  UINavigationController *navigationController = (UINavigationController *)presentedViewController;
+  NSAssert(navigationController.viewControllers.count == 1 && [navigationController.viewControllers.firstObject isKindOfClass:PSPDFViewController.class], @"Presented view controller needs to contain a PSPDFViewController");
+  PSPDFViewController *pdfViewController = (PSPDFViewController *)navigationController.viewControllers.firstObject;
+
+  [pdfViewController setPageIndex:pageIndex animated:animated];
+}
+
 - (dispatch_queue_t)methodQueue {
   return dispatch_get_main_queue();
 }

--- a/ios/RCTPSPDFKit/RCTPSPDFKitManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitManager.m
@@ -46,7 +46,7 @@ RCT_EXPORT_METHOD(dismiss) {
   [navigationController dismissViewControllerAnimated:true completion:nil];
 }
 
-RCT_EXPORT_METHOD(setPageIndex:(NSUInteger)pageIndex aniamted:(BOOL)animated) {
+RCT_EXPORT_METHOD(setPageIndex:(NSUInteger)pageIndex animated:(BOOL)animated) {
   UIViewController *presentedViewController = RCTPresentedViewController();
   NSAssert([presentedViewController isKindOfClass:UINavigationController.class], @"Presented view controller needs to be a UINavigationController");
   UINavigationController *navigationController = (UINavigationController *)presentedViewController;

--- a/samples/Catalog/Catalog.ios.js
+++ b/samples/Catalog/Catalog.ios.js
@@ -46,6 +46,7 @@ var examples = [
         }
       }).then(() => {
         PSPDFKit.present(path, {})
+        PSPDFKit.setPageIndex(3, false)
       }).catch((err) => {
         console.log(err.message, err.code);
       });


### PR DESCRIPTION
Adds `setPageIndex` API to the iOS wrapper, that allows changing pages programmatically, with an optional page change animation.