### PR TITLE
Add onDocumentSaved event for the UI Component

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ class PSPDFKitView extends React.Component {
                     {...this.props}
                     onCloseButtonPressed={onCloseButtonPressedHandler}
                     onStateChanged={this._onStateChanged}
+                    onDocumentSaved={this._onDocumentSaved}
                 />
             );
         } else {
@@ -39,6 +40,12 @@ class PSPDFKitView extends React.Component {
     _onStateChanged = event => {
         if (this.props.onStateChanged) {
             this.props.onStateChanged(event.nativeEvent);
+        }
+    };
+    
+    _onDocumentSaved = (event) => {
+        if (this.props.onDocumentSaved) {
+            this.props.onDocumentSaved(event.nativeEvent);
         }
     };
 
@@ -108,6 +115,14 @@ PSPDFKitView.propTypes = {
      * @platform ios
      */
     onCloseButtonPressed: PropTypes.func,
+    
+    /**
+     * Callback that is called when the document is saved.
+     *
+     * @platform ios
+     */
+    onDocumentSaved: PropTypes.func,
+    
     /**
      * Callback that is called when the state of the PSPDFKitView changes.
      * Returns an object with the following structure:

--- a/index.js
+++ b/index.js
@@ -115,14 +115,12 @@ PSPDFKitView.propTypes = {
      * @platform ios
      */
     onCloseButtonPressed: PropTypes.func,
-    
     /**
      * Callback that is called when the document is saved.
      *
      * @platform ios
      */
-    onDocumentSaved: PropTypes.func,
-    
+    onDocumentSaved: PropTypes.func, 
     /**
      * Callback that is called when the state of the PSPDFKitView changes.
      * Returns an object with the following structure:

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.h
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.h
@@ -20,5 +20,6 @@
 
 @property (nonatomic, readonly) UIBarButtonItem *closeButton;
 @property (nonatomic, copy) RCTBubblingEventBlock onCloseButtonPressed;
+@property (nonatomic, copy) RCTBubblingEventBlock onDocumentSaved;
 
 @end

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.h
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.h
@@ -17,7 +17,6 @@
 
 @property (nonatomic, readonly) PSPDFViewController *pdfController;
 @property (nonatomic) BOOL hideNavigationBar;
-
 @property (nonatomic, readonly) UIBarButtonItem *closeButton;
 @property (nonatomic, copy) RCTBubblingEventBlock onCloseButtonPressed;
 @property (nonatomic, copy) RCTBubblingEventBlock onDocumentSaved;

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -10,7 +10,7 @@
 #import "RCTPSPDFKitView.h"
 #import <React/RCTUtils.h>
 
-@interface RCTPSPDFKitView ()
+@interface RCTPSPDFKitView ()<PSPDFDocumentDelegate>
 
 @property (nonatomic, nullable) UIViewController *topController;
 
@@ -95,6 +95,14 @@
     }
   }
   return nil;
+}
+
+#pragma mark - PSPDFDocumentDelegate
+
+- (void)pdfDocumentDidSave:(nonnull PSPDFDocument *)document {
+  if (self.onDocumentSaved) {
+    self.onDocumentSaved(@{});
+  }
 }
 
 @end

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -15,9 +15,6 @@
 @import PSPDFKit;
 @import PSPDFKitUI;
 
-@interface RCTPSPDFKitViewManager() <PSPDFDocumentDelegate>
-@end
-
 @implementation RCTPSPDFKitViewManager
 
 RCT_EXPORT_MODULE()

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -9,16 +9,25 @@
 
 #import "RCTPSPDFKitViewManager.h"
 #import "RCTConvert+PSPDFConfiguration.h"
+#import "RCTConvert+PSPDFDocument.h"
 #import "RCTPSPDFKitView.h"
 
 @import PSPDFKit;
 @import PSPDFKitUI;
 
+@interface RCTPSPDFKitViewManager() <PSPDFDocumentDelegate>
+@end
+
 @implementation RCTPSPDFKitViewManager
 
 RCT_EXPORT_MODULE()
 
-RCT_REMAP_VIEW_PROPERTY(document, pdfController.document, PSPDFDocument)
+RCT_CUSTOM_VIEW_PROPERTY(document, pdfController.document, RCTPSPDFKitView) {
+  if (json) {
+    view.pdfController.document = [RCTConvert PSPDFDocument:json];
+    view.pdfController.document.delegate = (id<PSPDFDocumentDelegate>)view;
+  }
+}
 
 RCT_REMAP_VIEW_PROPERTY(pageIndex, pdfController.pageIndex, NSUInteger)
 
@@ -41,6 +50,8 @@ RCT_CUSTOM_VIEW_PROPERTY(showCloseButton, BOOL, RCTPSPDFKitView) {
 }
 
 RCT_EXPORT_VIEW_PROPERTY(onCloseButtonPressed, RCTBubblingEventBlock)
+
+RCT_EXPORT_VIEW_PROPERTY(onDocumentSaved, RCTBubblingEventBlock)
 
 - (UIView *)view {
   return [[RCTPSPDFKitView alloc] init];


### PR DESCRIPTION
The iOS implementation of #82 

## How to test

* Create a new React Native sample app: https://github.com/PSPDFKit/react-native#ios
* For step 4, use this branch: `yarn add github:PSPDFKit/react-native#rad/js-events-ios`
* For step 15, use the following code in your `App.js`

```javascript
import React, { Component } from 'react';
import { NativeModules } from 'react-native';
import PSPDFKitView from 'react-native-pspdfkit'

var PSPDFKit = NativeModules.PSPDFKit;
PSPDFKit.setLicenseKey('YOUR_LICENSE_KEY_GOES_HERE');

export default class App extends Component<{}> {
  render() {
    return (
      <PSPDFKitView
        document={'document.pdf'}
        configuration={{
          pageTransition: 'scrollContinuous',
          scrollDirection: 'vertical',
          documentLabelEnabled: true,
        }}
        style={{ flex: 1, color: '#267AD4' }}
        onDocumentSaved={this.onDocumentSaved}
      />
    )
  }
  onDocumentSaved() {
      alert('Document Saved');
  }
}
``` 

* Launch the app
* Add a new annotation
* Invoke the share sheet to trigger a document save.
* Observe the alert.

![recording](https://user-images.githubusercontent.com/7443038/42290978-a32db4ca-7f96-11e8-9858-6625b0ca8df6.gif)

## What to test:

- [x] Make sure that there are now issues on Android and Windows