### PR TITLE
Add onAnnotationTapped event for the UI Component

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ class PSPDFKitView extends React.Component {
                     onCloseButtonPressed={onCloseButtonPressedHandler}
                     onStateChanged={this._onStateChanged}
                     onDocumentSaved={this._onDocumentSaved}
+                    onAnnotationTapped={this._onAnnotationTapped}
                 />
             );
         } else {
@@ -46,6 +47,12 @@ class PSPDFKitView extends React.Component {
     _onDocumentSaved = (event) => {
         if (this.props.onDocumentSaved) {
             this.props.onDocumentSaved(event.nativeEvent);
+        }
+    };
+    
+    _onAnnotationTapped = (event) => {
+        if (this.props.onAnnotationTapped) {
+            this.props.onAnnotationTapped(event.nativeEvent);
         }
     };
 
@@ -108,6 +115,12 @@ PSPDFKitView.propTypes = {
      */
     showCloseButton: PropTypes.bool,
     /**
+     * Controls wheter or not the default action for tapped annotations is processed. Defaults to processing the action (false).
+     *
+     * @platform ios
+     */
+    disableDefaultActionForTappedAnnotations: PropTypes.bool, 
+    /**
      * Callback that is called when the user tapped the close button.
      * If you provide this function, you need to handle dismissal yourself.
      * If you don't provide this function, PSPDFKitView will be automatically dismissed.
@@ -120,7 +133,13 @@ PSPDFKitView.propTypes = {
      *
      * @platform ios
      */
-    onDocumentSaved: PropTypes.func, 
+    onDocumentSaved: PropTypes.func,
+    /**
+     * Callback that is called when the user taps on an annotation.
+     *
+     * @platform ios
+     */
+    onAnnotationTapped: PropTypes.func,    
     /**
      * Callback that is called when the state of the PSPDFKitView changes.
      * Returns an object with the following structure:
@@ -137,7 +156,6 @@ PSPDFKitView.propTypes = {
      * @platform android
      */
     onStateChanged: PropTypes.func,
-
     /**
      * fragmentTag: A tag used to identify a single PdfFragment in the view hierarchy.
      * This needs to be unique in the view hierarchy.

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.h
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.h
@@ -18,7 +18,9 @@
 @property (nonatomic, readonly) PSPDFViewController *pdfController;
 @property (nonatomic) BOOL hideNavigationBar;
 @property (nonatomic, readonly) UIBarButtonItem *closeButton;
+@property (nonatomic) BOOL disableDefaultActionForTappedAnnotations;
 @property (nonatomic, copy) RCTBubblingEventBlock onCloseButtonPressed;
 @property (nonatomic, copy) RCTBubblingEventBlock onDocumentSaved;
+@property (nonatomic, copy) RCTBubblingEventBlock onAnnotationTapped;
 
 @end

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -10,7 +10,7 @@
 #import "RCTPSPDFKitView.h"
 #import <React/RCTUtils.h>
 
-@interface RCTPSPDFKitView ()<PSPDFDocumentDelegate>
+@interface RCTPSPDFKitView ()<PSPDFDocumentDelegate, PSPDFViewControllerDelegate>
 
 @property (nonatomic, nullable) UIViewController *topController;
 
@@ -21,6 +21,7 @@
 - (instancetype)initWithFrame:(CGRect)frame {
   if ((self = [super initWithFrame:frame])) {
     _pdfController = [[PSPDFViewController alloc] init];
+    _pdfController.delegate = self;
     _closeButton = [[UIBarButtonItem alloc] initWithImage:[PSPDFKit imageNamed:@"x"] style:UIBarButtonItemStylePlain target:self action:@selector(closeButtonPressed:)];
   }
 
@@ -103,6 +104,17 @@
   if (self.onDocumentSaved) {
     self.onDocumentSaved(@{});
   }
+}
+
+#pragma mark - PSPDFViewControllerDelegate
+
+- (BOOL)pdfViewController:(PSPDFViewController *)pdfController didTapOnAnnotation:(PSPDFAnnotation *)annotation annotationPoint:(CGPoint)annotationPoint annotationView:(UIView<PSPDFAnnotationPresenting> *)annotationView pageView:(PSPDFPageView *)pageView viewPoint:(CGPoint)viewPoint {
+  if (self.onAnnotationTapped) {
+    NSData *annotationData = [annotation generateInstantJSONWithError:NULL];
+    NSDictionary *annotationDictionary = [NSJSONSerialization JSONObjectWithData:annotationData options:kNilOptions error:NULL];
+    self.onAnnotationTapped(annotationDictionary);
+  }
+  return self.disableDefaultActionForTappedAnnotations;
 }
 
 @end

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -38,6 +38,8 @@ RCT_CUSTOM_VIEW_PROPERTY(configuration, PSPDFConfiguration, RCTPSPDFKitView) {
 
 RCT_EXPORT_VIEW_PROPERTY(hideNavigationBar, BOOL)
 
+RCT_EXPORT_VIEW_PROPERTY(disableDefaultActionForTappedAnnotations, BOOL)
+
 RCT_REMAP_VIEW_PROPERTY(color, tintColor, UIColor)
 
 RCT_CUSTOM_VIEW_PROPERTY(showCloseButton, BOOL, RCTPSPDFKitView) {
@@ -49,6 +51,8 @@ RCT_CUSTOM_VIEW_PROPERTY(showCloseButton, BOOL, RCTPSPDFKitView) {
 RCT_EXPORT_VIEW_PROPERTY(onCloseButtonPressed, RCTBubblingEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(onDocumentSaved, RCTBubblingEventBlock)
+
+RCT_EXPORT_VIEW_PROPERTY(onAnnotationTapped, RCTBubblingEventBlock)
 
 - (UIView *)view {
   return [[RCTPSPDFKitView alloc] init];


### PR DESCRIPTION
The iOS implementation of #83 

---

- [x] Adds an event (`onAnnotationTapped`) for when the annotation is tapped.
- [x] Adds the ability to disable the default action for tapped annotations via `disableDefaultActionForTappedAnnotations`

---

## How to test

* Create a new React Native sample app: https://github.com/PSPDFKit/react-native#ios
* For step 4, use this branch: `yarn add github:PSPDFKit/react-native#rad/add-onAnnotationTapped-ios`
* For step 15, use the following code in your `App.js`

```javascript
import React, { Component } from 'react';
import { NativeModules } from 'react-native';
import PSPDFKitView from 'react-native-pspdfkit'

var PSPDFKit = NativeModules.PSPDFKit;
PSPDFKit.setLicenseKey('YOUR_LICENSE_KEY_GOES_HERE');

export default class App extends Component<{}> {
  render() {
    return (
      <PSPDFKitView
        document={'document.pdf'}
        configuration={{
          pageTransition: 'scrollContinuous',
          scrollDirection: 'vertical',
          documentLabelEnabled: true,
        }}
        style={{ flex: 1, color: '#267AD4' }}
        disableDefaultActionForTappedAnnotations={true}
        onAnnotationTapped={this.onAnnotationTapped}
      />
    )
  }
  onAnnotationTapped(event) {
      alert('tapped on Annotation: ' + JSON.stringify(event));
  }
}
``` 

* Launch the app
* Add a new annotation
* Exit the annotation mode by closing the annotation toolbar
* Tap on the added annotation
* Observe the alert

![recording](https://user-images.githubusercontent.com/7443038/42292187-af99c7dc-7f9e-11e8-9eb6-604cf6c3ebb8.gif)

## What to test:

- [ ] Make sure that there are now issues on Android and Windows