### PR TITLE
Add API and Catalog example to manually save a document

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,8 @@ PSPDFKitView.propTypes = {
     disableDefaultActionForTappedAnnotations: PropTypes.bool,
     /**
      * Controls whether or not the document will be automatically saved. Defaults to automatically saving (false).
+     *
+     * @platform ios
      */
     disableAutomaticSaving: PropTypes.bool,
     /**

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ class PSPDFKitView extends React.Component {
                     onCloseButtonPressed={onCloseButtonPressedHandler}
                     onStateChanged={this._onStateChanged}
                     onDocumentSaved={this._onDocumentSaved}
+                    onDocumentSaveFailed={this._onDocumentSaveFailed}
                     onAnnotationTapped={this._onAnnotationTapped}
                     onAnnotationsChanged={this._onAnnotationsChanged}
                 />
@@ -48,6 +49,12 @@ class PSPDFKitView extends React.Component {
     _onDocumentSaved = (event) => {
         if (this.props.onDocumentSaved) {
             this.props.onDocumentSaved(event.nativeEvent);
+        }
+    };
+    
+    _onDocumentSaveFailed = (event) => {
+        if (this.props.onDocumentSaveFailed) {
+            this.props.onDocumentSaveFailed(event.nativeEvent);
         }
     };
 
@@ -152,6 +159,14 @@ PSPDFKitView.propTypes = {
      * Callback that is called when the document is saved.
      */
     onDocumentSaved: PropTypes.func,
+    /**
+     * Callback that is called when the document fails to save.
+     * Returns a string error with the error message.
+     * {
+     *    error: "Error message",
+     * }
+     */
+    onDocumentSaveFailed: PropTypes.func,
     /**
      * Callback that is called when an annotation is added, changed, or removed.
      * Returns an object with the following structure:

--- a/index.js
+++ b/index.js
@@ -167,6 +167,8 @@ PSPDFKitView.propTypes = {
      * {
      *    error: "Error message",
      * }
+     *
+     * @platform ios
      */
     onDocumentSaveFailed: PropTypes.func,
     /**

--- a/index.js
+++ b/index.js
@@ -91,8 +91,6 @@ class PSPDFKitView extends React.Component {
 
     /**
      * Saves the currently opened document.
-     * 
-     * @platform android
      */
     saveCurrentDocument = function () {
         UIManager.dispatchViewManagerCommand(
@@ -138,6 +136,10 @@ PSPDFKitView.propTypes = {
      * Controls wheter or not the default action for tapped annotations is processed. Defaults to processing the action (false).
      */
     disableDefaultActionForTappedAnnotations: PropTypes.bool,
+    /**
+     * Controls whether or not the document will be automatically saved. Defaults to automatically saving (false).
+     */
+    disableAutomaticSaving: PropTypes.bool,
     /**
      * Callback that is called when the user tapped the close button.
      * If you provide this function, you need to handle dismissal yourself.

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.h
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.h
@@ -22,6 +22,7 @@
 @property (nonatomic) BOOL disableAutomaticSaving;
 @property (nonatomic, copy) RCTBubblingEventBlock onCloseButtonPressed;
 @property (nonatomic, copy) RCTBubblingEventBlock onDocumentSaved;
+@property (nonatomic, copy) RCTBubblingEventBlock onDocumentSaveFailed;
 @property (nonatomic, copy) RCTBubblingEventBlock onAnnotationTapped;
 @property (nonatomic, copy) RCTBubblingEventBlock onAnnotationsChanged;
 @property (nonatomic, copy) RCTBubblingEventBlock onStateChanged;

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.h
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.h
@@ -19,10 +19,13 @@
 @property (nonatomic) BOOL hideNavigationBar;
 @property (nonatomic, readonly) UIBarButtonItem *closeButton;
 @property (nonatomic) BOOL disableDefaultActionForTappedAnnotations;
+@property (nonatomic) BOOL disableAutomaticSaving;
 @property (nonatomic, copy) RCTBubblingEventBlock onCloseButtonPressed;
 @property (nonatomic, copy) RCTBubblingEventBlock onDocumentSaved;
 @property (nonatomic, copy) RCTBubblingEventBlock onAnnotationTapped;
 @property (nonatomic, copy) RCTBubblingEventBlock onAnnotationsChanged;
 @property (nonatomic, copy) RCTBubblingEventBlock onStateChanged;
+
+- (void)saveCurrentDocument;
 
 @end

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -103,6 +103,10 @@
   return nil;
 }
 
+- (void)saveCurrentDocument {
+  [self.pdfController.document saveWithOptions:nil error:NULL];
+}
+
 #pragma mark - PSPDFDocumentDelegate
 
 - (void)pdfDocumentDidSave:(nonnull PSPDFDocument *)document {
@@ -120,6 +124,10 @@
     self.onAnnotationTapped(annotationDictionary);
   }
   return self.disableDefaultActionForTappedAnnotations;
+}
+
+- (BOOL)pdfViewController:(PSPDFViewController *)pdfController shouldSaveDocument:(nonnull PSPDFDocument *)document withOptions:(NSDictionary<PSPDFDocumentSaveOption,id> *__autoreleasing  _Nonnull * _Nonnull)options {
+  return !self.disableAutomaticSaving;
 }
 
 - (void)pdfViewController:(PSPDFViewController *)pdfController willBeginDisplayingPageView:(PSPDFPageView *)pageView forPageAtIndex:(NSInteger)pageIndex {

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -104,6 +104,7 @@
 }
 
 - (void)saveCurrentDocument {
+  self.pdfController.document.annotationSaveMode = PSPDFAnnotationSaveModeEmbedded;
   [self.pdfController.document saveWithOptions:nil error:NULL];
 }
 
@@ -112,6 +113,12 @@
 - (void)pdfDocumentDidSave:(nonnull PSPDFDocument *)document {
   if (self.onDocumentSaved) {
     self.onDocumentSaved(@{});
+  }
+}
+
+- (void)pdfDocument:(PSPDFDocument *)document saveDidFailWithError:(NSError *)error {
+  if (self.onDocumentSaveFailed) {
+    self.onDocumentSaveFailed(@{@"error": error.description});
   }
 }
 

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -104,7 +104,6 @@
 }
 
 - (void)saveCurrentDocument {
-  self.pdfController.document.annotationSaveMode = PSPDFAnnotationSaveModeEmbedded;
   [self.pdfController.document saveWithOptions:nil error:NULL];
 }
 

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -55,6 +55,8 @@ RCT_EXPORT_VIEW_PROPERTY(onCloseButtonPressed, RCTBubblingEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(onDocumentSaved, RCTBubblingEventBlock)
 
+RCT_EXPORT_VIEW_PROPERTY(onDocumentSaveFailed, RCTBubblingEventBlock)
+
 RCT_EXPORT_VIEW_PROPERTY(onAnnotationTapped, RCTBubblingEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(onAnnotationsChanged, RCTBubblingEventBlock)

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -11,6 +11,7 @@
 #import "RCTConvert+PSPDFConfiguration.h"
 #import "RCTConvert+PSPDFDocument.h"
 #import "RCTPSPDFKitView.h"
+#import <React/RCTUIManager.h>
 
 @import PSPDFKit;
 @import PSPDFKitUI;
@@ -40,6 +41,8 @@ RCT_EXPORT_VIEW_PROPERTY(hideNavigationBar, BOOL)
 
 RCT_EXPORT_VIEW_PROPERTY(disableDefaultActionForTappedAnnotations, BOOL)
 
+RCT_EXPORT_VIEW_PROPERTY(disableAutomaticSaving, BOOL)
+
 RCT_REMAP_VIEW_PROPERTY(color, tintColor, UIColor)
 
 RCT_CUSTOM_VIEW_PROPERTY(showCloseButton, BOOL, RCTPSPDFKitView) {
@@ -57,6 +60,13 @@ RCT_EXPORT_VIEW_PROPERTY(onAnnotationTapped, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onAnnotationsChanged, RCTBubblingEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(onStateChanged, RCTBubblingEventBlock)
+
+RCT_EXPORT_METHOD(saveCurrentDocument:(nonnull NSNumber *)reactTag) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];
+    [component saveCurrentDocument];
+  });
+}
 
 - (UIView *)view {
   return [[RCTPSPDFKitView alloc] init];

--- a/samples/Catalog/Catalog.ios.js
+++ b/samples/Catalog/Catalog.ios.js
@@ -20,7 +20,6 @@ import {
   NavigatorIOS,
   Modal,
   Dimensions,
-  findNodeHandle,
 } from 'react-native'
 const RNFS = require('react-native-fs')
 
@@ -340,7 +339,7 @@ class ManualSave extends Component {
             <View>
               <Button onPress={() => {
                 // Manual Save
-                NativeModules.PSPDFKitViewManager.saveCurrentDocument(findNodeHandle(this.refs.pdfView));
+                this.refs.pdfView.saveCurrentDocument();
               }} disabled={false} title="Save" />
             </View>
           </View>

--- a/samples/Catalog/Catalog.ios.js
+++ b/samples/Catalog/Catalog.ios.js
@@ -20,6 +20,7 @@ import {
   NavigatorIOS,
   Modal,
   Dimensions,
+  findNodeHandle,
 } from 'react-native'
 const RNFS = require('react-native-fs')
 
@@ -102,6 +103,17 @@ var examples = [
     action: component => {
       const nextRoute = {
         component: ChangePages
+      }
+      component.props.navigator.push(nextRoute)
+    },
+  },
+  {
+    name: 'Manual Save',
+    description:
+      'Adds a toolbar at the bottom with a Save button and disables automatic saving.',
+    action: component => {
+      const nextRoute = {
+        component: ManualSave
       }
       component.props.navigator.push(nextRoute)
     },
@@ -278,25 +290,63 @@ class SplitPDF extends Component {
              <Text>
              {"Page " + (this.state.currentPageIndex + 1) + " of " + this.state.pageCount}
             </Text>
-           <View>
-             <Button onPress={() => {
-                 this.setState(previousState => {
-                 return { currentPageIndex: previousState.currentPageIndex - 1 }
-               })
-             }} disabled={this.state.currentPageIndex == 0} title="Previous Page" />
-           </View>
-           <View style={{ marginLeft: 10 }}>
-             <Button onPress={() => {
-                 this.setState(previousState => {
-                 return { currentPageIndex: previousState.currentPageIndex + 1 }
-               })
-             }} disabled={this.state.currentPageIndex == this.state.pageCount - 1} title="Next Page" />
+             <View>
+               <Button onPress={() => {
+                   this.setState(previousState => {
+                   return { currentPageIndex: previousState.currentPageIndex - 1 }
+                 })
+               }} disabled={this.state.currentPageIndex == 0} title="Previous Page" />
+             </View>
+             <View style={{ marginLeft: 10 }}>
+               <Button onPress={() => {
+                   this.setState(previousState => {
+                   return { currentPageIndex: previousState.currentPageIndex + 1 }
+                 })
+               }} disabled={this.state.currentPageIndex == this.state.pageCount - 1} title="Next Page" />
              </View>
            </View>
          </View>
        )
    }
    
+   _getOptimalLayoutDirection = () => {
+     const width = this.state.dimensions
+       ? this.state.dimensions.width
+       : Dimensions.get('window').width
+     return width > 450 ? 'row' : 'column'
+   }
+
+   _onLayout = event => {
+     let { width, height } = event.nativeEvent.layout
+     this.setState({ dimensions: { width, height } })
+   }
+}
+
+class ManualSave extends Component {
+  render() {
+     return (
+      <View style={{ flex: 1 }}>
+        <PSPDFKitView
+          ref="pdfView"
+          document={'PDFs/Annual Report.pdf'}
+          disableAutomaticSaving={true}
+          configuration={{
+            backgroundColor: processColor('lightgrey'),
+            thumbnailBarMode: 'scrollable',
+          }}
+          style={{ flex: 1, color: pspdfkitColor }}
+          />
+          <View style={{ flexDirection: 'row', height: 60, alignItems: 'center', padding: 10 }}>
+            <View>
+              <Button onPress={() => {
+                // Manual Save
+                NativeModules.PSPDFKitViewManager.saveCurrentDocument(findNodeHandle(this.refs.pdfView));
+              }} disabled={false} title="Save" />
+            </View>
+          </View>
+        </View>
+       )
+     }
    _getOptimalLayoutDirection = () => {
      const width = this.state.dimensions
        ? this.state.dimensions.width

--- a/samples/Catalog/Catalog.ios.js
+++ b/samples/Catalog/Catalog.ios.js
@@ -307,18 +307,6 @@ class SplitPDF extends Component {
          </View>
        )
    }
-   
-   _getOptimalLayoutDirection = () => {
-     const width = this.state.dimensions
-       ? this.state.dimensions.width
-       : Dimensions.get('window').width
-     return width > 450 ? 'row' : 'column'
-   }
-
-   _onLayout = event => {
-     let { width, height } = event.nativeEvent.layout
-     this.setState({ dimensions: { width, height } })
-   }
 }
 
 class ManualSave extends Component {
@@ -335,28 +323,17 @@ class ManualSave extends Component {
           }}
           style={{ flex: 1, color: pspdfkitColor }}
           />
-          <View style={{ flexDirection: 'row', height: 60, alignItems: 'center', padding: 10 }}>
-            <View>
-              <Button onPress={() => {
-                // Manual Save
-                this.refs.pdfView.saveCurrentDocument();
-              }} disabled={false} title="Save" />
-            </View>
+        <View style={{ flexDirection: 'row', height: 60, alignItems: 'center', padding: 10 }}>
+          <View>
+            <Button onPress={() => {
+              // Manual Save
+              this.refs.pdfView.saveCurrentDocument();
+            }} disabled={false} title="Save" />
           </View>
         </View>
-       )
-     }
-   _getOptimalLayoutDirection = () => {
-     const width = this.state.dimensions
-       ? this.state.dimensions.width
-       : Dimensions.get('window').width
-     return width > 450 ? 'row' : 'column'
-   }
-
-   _onLayout = event => {
-     let { width, height } = event.nativeEvent.layout
-     this.setState({ dimensions: { width, height } })
-   }
+      </View> 
+    )
+  }
 }
 
 export default class Catalog extends Component {


### PR DESCRIPTION
Fixes #85 

---

- Adds `saveCurrentDocument` which instantly saves the currently displayed document.
- Adds `disableAutomaticSaving` prop to disable automatic saving when exiting the document.
- Adds `onDocumentSaveFailed ` callback when saving fails.
- Adds Manual Save Catalog example.