### PR TITLE
Add annotationAuthorName prop to set the annotation author

### DIFF
--- a/index.js
+++ b/index.js
@@ -250,8 +250,6 @@ PSPDFKitView.propTypes = {
      * Controls the author name that is set for new annotations.
      * If not set and the user hasn't specified it before the user will be asked and the result will be saved.
      * The value set here will be persisted and the user will not be asked even if this is not set the next time.
-     * 
-     * @platform android
      */
     annotationAuthorName: PropTypes.string,
     /**

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.h
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.h
@@ -20,7 +20,7 @@
 @property (nonatomic, readonly) UIBarButtonItem *closeButton;
 @property (nonatomic) BOOL disableDefaultActionForTappedAnnotations;
 @property (nonatomic) BOOL disableAutomaticSaving;
-@property (atomic, copy, nullable) NSString *annotationAuthorName;
+@property (nonatomic, copy, nullable) NSString *annotationAuthorName;
 @property (nonatomic, copy) RCTBubblingEventBlock onCloseButtonPressed;
 @property (nonatomic, copy) RCTBubblingEventBlock onDocumentSaved;
 @property (nonatomic, copy) RCTBubblingEventBlock onDocumentSaveFailed;

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.h
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.h
@@ -20,6 +20,7 @@
 @property (nonatomic, readonly) UIBarButtonItem *closeButton;
 @property (nonatomic) BOOL disableDefaultActionForTappedAnnotations;
 @property (nonatomic) BOOL disableAutomaticSaving;
+@property (atomic, copy, nullable) NSString *annotationAuthorName;
 @property (nonatomic, copy) RCTBubblingEventBlock onCloseButtonPressed;
 @property (nonatomic, copy) RCTBubblingEventBlock onDocumentSaved;
 @property (nonatomic, copy) RCTBubblingEventBlock onDocumentSaveFailed;

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -24,6 +24,11 @@ RCT_CUSTOM_VIEW_PROPERTY(document, pdfController.document, RCTPSPDFKitView) {
   if (json) {
     view.pdfController.document = [RCTConvert PSPDFDocument:json];
     view.pdfController.document.delegate = (id<PSPDFDocumentDelegate>)view;
+
+    // The author name may be set before the document exists. We set it again here when the document exists.
+    if (view.annotationAuthorName) {
+      view.pdfController.document.defaultAnnotationUsername = view.annotationAuthorName;
+    }
   }
 }
 
@@ -34,6 +39,13 @@ RCT_CUSTOM_VIEW_PROPERTY(configuration, PSPDFConfiguration, RCTPSPDFKitView) {
     [view.pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder *builder) {
       [builder setupFromJSON:json];
     }];
+  }
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(annotationAuthorName, pdfController.document.defaultAnnotationUsername, RCTPSPDFKitView) {
+  if (json) {
+    view.pdfController.document.defaultAnnotationUsername = json;
+    view.annotationAuthorName = json;
   }
 }
 


### PR DESCRIPTION
iOS implementation for #84

---

- Adds annotationAuthorName prop to set the annotation author used when creating annotations.