### PR TITLE
Example showing how to customize the annotation toolbar in Objective-C

### DIFF
--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -17,7 +17,7 @@
 @import PSPDFKit;
 @import PSPDFKitUI;
 
-// Custom annotation toolbar subclass that adds a "Clear" button that removes all visible annotations OR the current drawing view state.
+// Custom annotation toolbar subclass that adds a "Clear" button that removes all visible annotations.
 @interface CustomButtonAnnotationToolbar : PSPDFAnnotationToolbar
 @property (nonatomic) PSPDFToolbarButton *clearAnnotationsButton;
 @end
@@ -174,7 +174,7 @@ RCT_EXPORT_METHOD(addAnnotations:(NSString *)jsonAnnotations reactTag:(nonnull N
 #pragma mark - Clear Button Action
 
 - (void)clearButtonPressed:(id)sender {
-  // Iterate over all visible pages and remove all but links.
+  // Iterate over all visible pages and remove all but links and widgets (forms).
   PSPDFViewController *pdfController = self.annotationStateManager.pdfController;
   PSPDFDocument *document = pdfController.document;
   for (PSPDFPageView *pageView in pdfController.visiblePageViews) {

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -17,6 +17,11 @@
 @import PSPDFKit;
 @import PSPDFKitUI;
 
+// Custom annotation toolbar subclass that adds a "Clear" button that removes all visible annotations OR the current drawing view state.
+@interface CustomButtonAnnotationToolbar : PSPDFAnnotationToolbar
+@property (nonatomic) PSPDFToolbarButton *clearAnnotationsButton;
+@end
+
 @implementation RCTPSPDFKitViewManager
 
 RCT_EXPORT_MODULE()
@@ -30,6 +35,11 @@ RCT_CUSTOM_VIEW_PROPERTY(document, pdfController.document, RCTPSPDFKitView) {
     if (view.annotationAuthorName) {
       view.pdfController.document.defaultAnnotationUsername = view.annotationAuthorName;
     }
+
+    // Update the configuration to use the custom annotation tool bar.
+    [view.pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder * _Nonnull builder) {
+      [builder overrideClass:PSPDFAnnotationToolbar.class withClass:CustomButtonAnnotationToolbar.class];
+    }];
   }
 }
 
@@ -123,6 +133,99 @@ RCT_EXPORT_METHOD(addAnnotations:(NSString *)jsonAnnotations reactTag:(nonnull N
 
 - (UIView *)view {
   return [[RCTPSPDFKitView alloc] init];
+}
+
+@end
+
+@implementation CustomButtonAnnotationToolbar
+
+///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - Lifecycle
+
+- (instancetype)initWithAnnotationStateManager:(PSPDFAnnotationStateManager *)annotationStateManager {
+  if ((self = [super initWithAnnotationStateManager:annotationStateManager])) {
+    // The biggest challenge here isn't the clear button, but correctly updating the clear button if we actually can clear something or not.
+    NSNotificationCenter *dnc = NSNotificationCenter.defaultCenter;
+    [dnc addObserver:self selector:@selector(annotationChangedNotification:) name:PSPDFAnnotationChangedNotification object:nil];
+    [dnc addObserver:self selector:@selector(annotationChangedNotification:) name:PSPDFAnnotationsAddedNotification object:nil];
+    [dnc addObserver:self selector:@selector(annotationChangedNotification:) name:PSPDFAnnotationsRemovedNotification object:nil];
+
+    // We could also use the delegate, but this is cleaner.
+    [dnc addObserver:self selector:@selector(willShowSpreadViewNotification:) name:PSPDFDocumentViewControllerWillBeginDisplayingSpreadViewNotification object:nil];
+
+    // Add clear button
+    UIImage *clearImage = [[PSPDFKit imageNamed:@"trash"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    _clearAnnotationsButton = [PSPDFToolbarButton new];
+    _clearAnnotationsButton.accessibilityLabel = @"Clear";
+    [_clearAnnotationsButton setImage:clearImage];
+    [_clearAnnotationsButton addTarget:self action:@selector(clearButtonPressed:) forControlEvents:UIControlEventTouchUpInside];
+
+    [self updateClearAnnotationButton];
+    self.additionalButtons = @[_clearAnnotationsButton];
+  }
+  return self;
+}
+
+- (void)dealloc {
+  [NSNotificationCenter.defaultCenter removeObserver:self];
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - Clear Button Action
+
+- (void)clearButtonPressed:(id)sender {
+  // Iterate over all visible pages and remove all but links.
+  PSPDFViewController *pdfController = self.annotationStateManager.pdfController;
+  PSPDFDocument *document = pdfController.document;
+  for (PSPDFPageView *pageView in pdfController.visiblePageViews) {
+    NSArray<PSPDFAnnotation *> *annotations = [document annotationsForPageAtIndex:pageView.pageIndex type:PSPDFAnnotationTypeAll & ~(PSPDFAnnotationTypeLink | PSPDFAnnotationTypeWidget)];
+    [document removeAnnotations:annotations options:nil];
+
+    // Remove any annotation on the page as well (updates views)
+    // Alternatively, you can call `reloadData` on the pdfController as well.
+    for (PSPDFAnnotation *annotation in annotations) {
+      [pageView removeAnnotation:annotation options:nil animated:YES];
+    }
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - Notifications
+
+// If we detect annotation changes, schedule a reload.
+- (void)annotationChangedNotification:(NSNotification *)notification {
+  // Re-evaluate toolbar button
+  if (self.window) {
+    [self updateClearAnnotationButton];
+  }
+}
+
+- (void)willShowSpreadViewNotification:(NSNotification *)notification {
+  [self updateClearAnnotationButton];
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - PSPDFAnnotationStateManagerDelegate
+
+- (void)annotationStateManager:(PSPDFAnnotationStateManager *)manager didChangeUndoState:(BOOL)undoEnabled redoState:(BOOL)redoEnabled {
+  [super annotationStateManager:manager didChangeUndoState:undoEnabled redoState:redoEnabled];
+  [self updateClearAnnotationButton];
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - Private
+
+- (void)updateClearAnnotationButton {
+  __block BOOL annotationsFound = NO;
+  PSPDFViewController *pdfController = self.annotationStateManager.pdfController;
+  [pdfController.visiblePageIndexes enumerateIndexesUsingBlock:^(NSUInteger pageIndex, BOOL *stop) {
+    NSArray<PSPDFAnnotation *> *annotations = [pdfController.document annotationsForPageAtIndex:pageIndex type:PSPDFAnnotationTypeAll & ~(PSPDFAnnotationTypeLink | PSPDFAnnotationTypeWidget)];
+    if (annotations.count > 0) {
+      annotationsFound = YES;
+      *stop = YES;
+    }
+  }];
+  self.clearAnnotationsButton.enabled = annotationsFound;
 }
 
 @end


### PR DESCRIPTION
# Details:

This PR will be merged to `customize-the-toolbar-in-native-code` and not master. 

The purpose of this PR is to illustrate how to customize the toolbar using native code from [PSPDFCatalog](https://pspdfkit.com/guides/ios/current/getting-started/example-projects/#pspdfcatalog). In this case, `PSCAnnotationToolbarButtonsExample.m`.

## Acceptance Criteria:

- [x] Add example showing how to customize the annotation toolbar in Objective-C.