### PR TITLE
Add the ability to programmatically toggle the annotation toolbar

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,28 +89,32 @@ class PSPDFKitView extends React.Component {
 
     /**
      * Enters the annotation creation mode, showing the annotation creation toolbar.
-     *
-     * @platform android
      */
     enterAnnotationCreationMode = function () {
-        UIManager.dispatchViewManagerCommand(
-            findNodeHandle(this.refs.pdfView),
-            UIManager.RCTPSPDFKitView.Commands.enterAnnotationCreationMode,
-            []
-        );
+        if (Platform.OS === "android") {
+            UIManager.dispatchViewManagerCommand(
+                findNodeHandle(this.refs.pdfView),
+                UIManager.RCTPSPDFKitView.Commands.enterAnnotationCreationMode,
+                []
+            );
+        } else if (Platform.OS === "ios") {
+            NativeModules.PSPDFKitViewManager.enterAnnotationCreationMode(findNodeHandle(this.refs.pdfView));
+        }
     };
 
     /**
      * Exits the currently active mode, hiding all toolbars.
-     *
-     * @platform android
      */
     exitCurrentlyActiveMode = function () {
-        UIManager.dispatchViewManagerCommand(
-            findNodeHandle(this.refs.pdfView),
-            UIManager.RCTPSPDFKitView.Commands.exitCurrentlyActiveMode,
-            []
-        );
+        if (Platform.OS === "android") {
+            UIManager.dispatchViewManagerCommand(
+                findNodeHandle(this.refs.pdfView),
+                UIManager.RCTPSPDFKitView.Commands.exitCurrentlyActiveMode,
+                []
+            );
+        } else if (Platform.OS === "ios") {
+            NativeModules.PSPDFKitViewManager.exitCurrentlyActiveMode(findNodeHandle(this.refs.pdfView));
+        }
     };
 
     /**

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.h
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.h
@@ -28,6 +28,10 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onAnnotationsChanged;
 @property (nonatomic, copy) RCTBubblingEventBlock onStateChanged;
 
+/// Annotation Toolbar
+- (void)enterAnnotationCreationMode;
+- (void)exitCurrentlyActiveMode;
+
 /// Document
 - (void)saveCurrentDocument;
 

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -104,6 +104,16 @@
   return nil;
 }
 
+- (void)enterAnnotationCreationMode {
+  [self.pdfController setViewMode:PSPDFViewModeDocument animated:YES];
+  [self.pdfController.annotationToolbarController updateHostView:nil container:nil viewController:self.pdfController];
+  [self.pdfController.annotationToolbarController showToolbarAnimated:YES];
+}
+
+- (void)exitCurrentlyActiveMode {
+  [self.pdfController.annotationToolbarController hideToolbarAnimated:YES];
+}
+
 - (void)saveCurrentDocument {
   [self.pdfController.document saveWithOptions:nil error:NULL];
 }

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -76,6 +76,20 @@ RCT_EXPORT_VIEW_PROPERTY(onAnnotationsChanged, RCTBubblingEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(onStateChanged, RCTBubblingEventBlock)
 
+RCT_EXPORT_METHOD(enterAnnotationCreationMode:(nonnull NSNumber *)reactTag) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];
+    [component enterAnnotationCreationMode];
+  });
+}
+
+RCT_EXPORT_METHOD(exitCurrentlyActiveMode:(nonnull NSNumber *)reactTag) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];
+    [component exitCurrentlyActiveMode];
+  });
+}
+
 RCT_EXPORT_METHOD(saveCurrentDocument:(nonnull NSNumber *)reactTag) {
   dispatch_async(dispatch_get_main_queue(), ^{
     RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];

--- a/samples/Catalog/Catalog.ios.js
+++ b/samples/Catalog/Catalog.ios.js
@@ -118,12 +118,12 @@ var examples = [
     },
   },
   {
-    name: 'Show and Hide the Annotation Toolbar',
+    name: 'Enter and Exit the Annotation Creation Mode',
     description:
-      'Adds a toolbar at the bottom with a button to toggle the visibility of the annotation toolbar.',
+      'Adds a toolbar at the bottom with a button to toggle the annotation toolbar.',
     action: component => {
       const nextRoute = {
-        component: ToggleAnnotationToolbar
+        component: AnnotationCreationMode
       }
       component.props.navigator.push(nextRoute)
     },
@@ -309,6 +309,7 @@ class SplitPDF extends Component {
              configuration={{
                backgroundColor: processColor('lightgrey'),
                thumbnailBarMode: 'scrollable',
+               useParentNavigationBar: true,
              }}
              showCloseButton={true}
              style={{ flex: 1, color: pspdfkitColor }}
@@ -358,6 +359,7 @@ class ChangePages extends Component {
              configuration={{
                backgroundColor: processColor('lightgrey'),
                thumbnailBarMode: 'scrollable',
+               useParentNavigationBar: true,
              }}
              pageIndex={this.state.currentPageIndex}
              showCloseButton={true}
@@ -394,15 +396,24 @@ class ChangePages extends Component {
    }
 }
 
-class ToggleAnnotationToolbar extends Component {
+class AnnotationCreationMode extends Component {
    constructor(props) {
      super(props)
      this.state = {
-       isVisible: false,
+      annotationCreationActive: false,
+      annotationEditingActive: false,
      };
    }
-
+   
    render() {
+       let buttonTitle = "";
+       if (this.state.annotationCreationActive) {
+         buttonTitle = "Exit Annotation Creation Mode";
+       } else if (this.state.annotationEditingActive) {
+         buttonTitle = "Exit Annotation Editing Mode";
+       } else {
+         buttonTitle = "Enter Annotation Creation Mode";
+       }
        return (
          <View style={{ flex: 1 }}>
            <PSPDFKitView
@@ -411,6 +422,7 @@ class ToggleAnnotationToolbar extends Component {
              configuration={{
                backgroundColor: processColor('lightgrey'),
                thumbnailBarMode: 'scrollable',
+               useParentNavigationBar: true,  
              }}
              pageIndex={this.state.currentPageIndex}
              showCloseButton={true}
@@ -418,22 +430,26 @@ class ToggleAnnotationToolbar extends Component {
              style={{ flex: 1, color: pspdfkitColor }}
              onStateChanged={event => {
                this.setState({
-                 isVisible: event.currentPageIndex
+                 annotationCreationActive: event.annotationCreationActive,
+                 annotationEditingActive: event.annotationEditingActive,
                });
              }}
            />
            <View style={{ flexDirection: 'row', height: 60, alignItems: 'center', padding: 10 }}>
              <View>
                <Button onPress={() => {
-                   if (this.state.isVisible) {
-                     this.refs.pdfView.exitCurrentlyActiveMode(); 
+                   if (this.state.annotationCreationActive || this.state.annotationEditingActive) {
+                     this.refs.pdfView.exitCurrentlyActiveMode();
                    } else {
                      this.refs.pdfView.enterAnnotationCreationMode();
                    }
                    this.setState(previousState => {                       
-                   return { isVisible: !previousState.isVisible }
+                   return { 
+                       annotationCreationActive: !previousState.annotationCreationActive, 
+                       annotationEditingActive: !previousState.annotationEditingActive
+                   }
                  })
-               }} title="Toggle" />
+               }} title={buttonTitle} />
              </View>
            </View>
          </View>
@@ -452,6 +468,7 @@ class ManualSave extends Component {
           configuration={{
             backgroundColor: processColor('lightgrey'),
             thumbnailBarMode: 'scrollable',
+            useParentNavigationBar: true,
           }}
           style={{ flex: 1, color: pspdfkitColor }}
           />
@@ -485,6 +502,7 @@ class ProgrammaticAnnotations extends Component {
           configuration={{
             backgroundColor: processColor('lightgrey'),
             thumbnailBarMode: 'scrollable',
+            useParentNavigationBar: true, 
           }}
           style={{ flex: 1, color: pspdfkitColor }}
           onStateChanged={event => {
@@ -539,6 +557,7 @@ class ProgrammaticFormFilling extends Component {
           configuration={{
             backgroundColor: processColor('lightgrey'),
             thumbnailBarMode: 'scrollable',
+            useParentNavigationBar: true,
           }}
           style={{ flex: 1, color: pspdfkitColor }}
           />

--- a/samples/Catalog/Catalog.ios.js
+++ b/samples/Catalog/Catalog.ios.js
@@ -109,10 +109,21 @@ var examples = [
   {
     name: 'Change Pages Buttons',
     description:
-      'Adds a toolbar at the bottom with buttons to the change pages.',
+      'Adds a toolbar at the bottom with buttons to change pages.',
     action: component => {
       const nextRoute = {
         component: ChangePages
+      }
+      component.props.navigator.push(nextRoute)
+    },
+  },
+  {
+    name: 'Show and Hide the Annotation Toolbar',
+    description:
+      'Adds a toolbar at the bottom with a button to toggle the visibility of the annotation toolbar.',
+    action: component => {
+      const nextRoute = {
+        component: ToggleAnnotationToolbar
       }
       component.props.navigator.push(nextRoute)
     },
@@ -376,6 +387,53 @@ class ChangePages extends Component {
                    return { currentPageIndex: previousState.currentPageIndex + 1 }
                  })
                }} disabled={this.state.currentPageIndex == this.state.pageCount - 1} title="Next Page" />
+             </View>
+           </View>
+         </View>
+       )
+   }
+}
+
+class ToggleAnnotationToolbar extends Component {
+   constructor(props) {
+     super(props)
+     this.state = {
+       isVisible: false,
+     };
+   }
+
+   render() {
+       return (
+         <View style={{ flex: 1 }}>
+           <PSPDFKitView
+             ref="pdfView"
+             document={'PDFs/Annual Report.pdf'}
+             configuration={{
+               backgroundColor: processColor('lightgrey'),
+               thumbnailBarMode: 'scrollable',
+             }}
+             pageIndex={this.state.currentPageIndex}
+             showCloseButton={true}
+             onCloseButtonPressed={this.props.onClose}
+             style={{ flex: 1, color: pspdfkitColor }}
+             onStateChanged={event => {
+               this.setState({
+                 isVisible: event.currentPageIndex
+               });
+             }}
+           />
+           <View style={{ flexDirection: 'row', height: 60, alignItems: 'center', padding: 10 }}>
+             <View>
+               <Button onPress={() => {
+                   if (this.state.isVisible) {
+                     this.refs.pdfView.exitCurrentlyActiveMode(); 
+                   } else {
+                     this.refs.pdfView.enterAnnotationCreationMode();
+                   }
+                   this.setState(previousState => {                       
+                   return { isVisible: !previousState.isVisible }
+                 })
+               }} title="Toggle" />
              </View>
            </View>
          </View>


### PR DESCRIPTION
# Details:

![recording](https://user-images.githubusercontent.com/7443038/43642650-6e5b2382-96f6-11e8-844a-a5dcb45dfb6e.gif)

# Acceptance Criteria:

- [ ] Implement `enterAnnotationCreationMode` and `exitCurrentlyActiveMode` on iOS
- [ ] Add catalog example showing how to programmatically toggle the annotation toolbar