### PR TITLE
Add missing `onStateChanged` for iOS

### DIFF
--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -109,7 +109,7 @@ RCT_REMAP_METHOD(getAnnotations, getAnnotations:(nonnull NSNumber *)pageIndex ty
   });
 }
 
-RCT_EXPORT_METHOD(addAnnotation:(NSString *)jsonAnnotation reactTag:(nonnull NSNumber *)reactTag) {
+RCT_EXPORT_METHOD(addAnnotation:(id)jsonAnnotation reactTag:(nonnull NSNumber *)reactTag) {
   dispatch_async(dispatch_get_main_queue(), ^{
     RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];
     [component addAnnotation:jsonAnnotation];
@@ -128,7 +128,7 @@ RCT_EXPORT_METHOD(getAllUnsavedAnnotations:(nonnull NSNumber *)reactTag resolver
   });
 }
 
-RCT_EXPORT_METHOD(addAnnotations:(NSString *)jsonAnnotations reactTag:(nonnull NSNumber *)reactTag) {
+RCT_EXPORT_METHOD(addAnnotations:(id)jsonAnnotations reactTag:(nonnull NSNumber *)reactTag) {
   dispatch_async(dispatch_get_main_queue(), ^{
     RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];
     [component addAnnotations:jsonAnnotations];

--- a/samples/Catalog/Catalog.ios.js
+++ b/samples/Catalog/Catalog.ios.js
@@ -407,33 +407,33 @@ class AnnotationCreationMode extends Component {
 
   render() {
     let buttonTitle = "";
-    if (this.state.annotationCreationActive) {
-      buttonTitle = "Exit Annotation Creation Mode";
-    } else if (this.state.annotationEditingActive) {
-      buttonTitle = "Exit Annotation Editing Mode";
-    } else {
-      buttonTitle = "Enter Annotation Creation Mode";
-    }
-    return (
-      <View style={{ flex: 1 }}>
-        <PSPDFKitView
-          ref="pdfView"
-          document={'PDFs/Annual Report.pdf'}
-          configuration={{
-            backgroundColor: processColor('lightgrey'),
-            thumbnailBarMode: 'scrollable',
-            useParentNavigationBar: true,
-          }}
-          pageIndex={this.state.currentPageIndex}
-          showCloseButton={true}
-          onCloseButtonPressed={this.props.onClose}
-          style={{ flex: 1, color: pspdfkitColor }}
-          onStateChanged={event => {
-            this.setState({
-              annotationCreationActive: event.annotationCreationActive,
-              annotationEditingActive: event.annotationEditingActive,
-            });
-          }}
+      if (this.state.annotationCreationActive) {
+        buttonTitle = "Exit Annotation Creation Mode";
+      } else if (this.state.annotationEditingActive) {
+        buttonTitle = "Exit Annotation Editing Mode";
+      } else {
+        buttonTitle = "Enter Annotation Creation Mode";
+      }
+      return (
+        <View style={{ flex: 1 }}>
+          <PSPDFKitView
+            ref="pdfView"
+            document={'PDFs/Annual Report.pdf'}
+            configuration={{
+              backgroundColor: processColor('lightgrey'),
+              thumbnailBarMode: 'scrollable',
+              useParentNavigationBar: true,
+            }}
+            pageIndex={this.state.currentPageIndex}
+            showCloseButton={true}
+            onCloseButtonPressed={this.props.onClose}
+            style={{ flex: 1, color: pspdfkitColor }}
+            onStateChanged={event => {
+              this.setState({
+                annotationCreationActive: event.annotationCreationActive,
+                annotationEditingActive: event.annotationEditingActive,
+              });
+            }}
         />
         <View style={{ flexDirection: 'row', height: 60, alignItems: 'center', padding: 10 }}>
           <View>
@@ -443,12 +443,6 @@ class AnnotationCreationMode extends Component {
               } else {
                 this.refs.pdfView.enterAnnotationCreationMode();
               }
-              this.setState(previousState => {
-                return {
-                  annotationCreationActive: !previousState.annotationCreationActive,
-                  annotationEditingActive: !previousState.annotationEditingActive
-                }
-              })
             }} title={buttonTitle} />
           </View>
         </View>


### PR DESCRIPTION
Implement `onStateChanged` just like on Android.


See: Z#9490

Also fixes an issue where `addAnnotation(s):` required the JSON payload to be a string. It can now be an object. See https://github.com/PSPDFKit/react-native/pull/110/files#r208223751