### PR TITLE
UWP issue when no document is passed.

### DIFF
--- a/samples/Catalog/windows/Catalog/Catalog.csproj
+++ b/samples/Catalog/windows/Catalog/Catalog.csproj
@@ -234,11 +234,6 @@
       <Name>PSPDFKit for UWP</Name>
     </SDKReference>
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.1.5</Version>
-    </PackageReference>
-  </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PDFViewPage.xaml
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PDFViewPage.xaml
@@ -4,5 +4,5 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="using:PSPDFKit.UI">
 
-    <ui:PdfView License="{StaticResource PSPDFKitLicense}" Name="PDFView"/>
+    <ui:PdfView License="{StaticResource PSPDFKitLicense}" Name="PDFView" InitializationCompletedHandler="PDFView_InitializationCompletedHandlerAsync"/>
 </Page>

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PDFViewPage.xaml.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PDFViewPage.xaml.cs
@@ -1,4 +1,13 @@
-﻿using System;
+﻿//
+//  Copyright © 2018 PSPDFKit GmbH. All rights reserved.
+//
+//  THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY INTERNATIONAL COPYRIGHT LAW
+//  AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT.
+//  UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
+//  This notice may not be removed from this file.
+//
+
+using System;
 using System.Threading.Tasks;
 using PSPDFKit.Document;
 using PSPDFKit.UI;
@@ -6,21 +15,17 @@ using Windows.Storage;
 using Windows.UI.Popups;
 using Windows.UI.Xaml.Controls;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace ReactNativePSPDFKit
 {
     public sealed partial class PDFViewPage : Page
     {
-        private ViewState _viewStateCache = new ViewState();
+        private readonly ViewState _viewStateCache = new ViewState();
         private StorageFile _fileToOpen = null;
         private bool _pdfViewInitialised = false;
         
         public PDFViewPage()
         {
             InitializeComponent();
-
-            PDFView.InitializationCompletedHandler += PDFView_InitializationCompletedHandlerAsync;
         }
 
         /// <summary>
@@ -31,11 +36,12 @@ namespace ReactNativePSPDFKit
         {
             _fileToOpen = file;
 
+            // If the PdfView is already initialised we can show the new document.
             if(_pdfViewInitialised)
             {
                 try
                 {
-                    await PDFView.Controller.ShowDocumentAsync(DocumentSource.CreateFromStorageFile(file));
+                    await PDFView.Controller.ShowDocumentWithViewStateAsync(DocumentSource.CreateFromStorageFile(file), _viewStateCache);
                 }
                 catch (Exception e)
                 {
@@ -50,6 +56,7 @@ namespace ReactNativePSPDFKit
         {
             _viewStateCache.CurrentPageIndex = index;
 
+            // If the PdfView is already initialised we can change the page index.
             if (_pdfViewInitialised)
             {
                 await PDFView.Controller.SetCurrentPageIndexAsync(index);
@@ -63,9 +70,13 @@ namespace ReactNativePSPDFKit
             PDFView.ShowToolbar = showToolbar;
         }
 
-        private async void PDFView_InitializationCompletedHandlerAsync(PdfView sender, PSPDFKit.Pdf.Document args)
+        private async void PDFView_InitializationCompletedHandlerAsync(PdfView sender, PSPDFKit.Pdf.Document document)
         {
-            await PDFView.Controller.ShowDocumentWithViewStateAsync(DocumentSource.CreateFromStorageFile(_fileToOpen), _viewStateCache);
+            // If we already have a file to open lets proceed with that here.
+            if (_fileToOpen != null)
+            {
+                await PDFView.Controller.ShowDocumentWithViewStateAsync(DocumentSource.CreateFromStorageFile(_fileToOpen), _viewStateCache);
+            }
             _pdfViewInitialised = true;
         }
     }

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitModule.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitModule.cs
@@ -1,5 +1,12 @@
-﻿using PSPDFKit.Document;
-using PSPDFKit.UI;
+﻿//
+//  Copyright © 2018 PSPDFKit GmbH. All rights reserved.
+//
+//  THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY INTERNATIONAL COPYRIGHT LAW
+//  AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT.
+//  UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
+//  This notice may not be removed from this file.
+//
+
 using ReactNative.Bridge;
 using System;
 using System.Collections.Generic;
@@ -13,7 +20,7 @@ namespace ReactNativePSPDFKit
     /// </summary>
     class PSPDFKitModule : ReactContextNativeModuleBase
     {
-        private PSPDFKitViewManger _pspdfKitViewManger;
+        private readonly PSPDFKitViewManger _pspdfKitViewManger;
         private string VERSION_KEY = "versionString";
 
         public PSPDFKitModule(ReactContext reactContext, PSPDFKitViewManger pspdfKitViewManger) : base(reactContext)

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitPackage.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitPackage.cs
@@ -1,6 +1,12 @@
-﻿using PSPDFKit;
-using PSPDFKit.Pdf;
-using PSPDFKit.UI;
+﻿//
+//  Copyright © 2018 PSPDFKit GmbH. All rights reserved.
+//
+//  THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY INTERNATIONAL COPYRIGHT LAW
+//  AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT.
+//  UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
+//  This notice may not be removed from this file.
+//
+
 using ReactNative.Bridge;
 using ReactNative.Modules.Core;
 using ReactNative.UIManager;
@@ -17,7 +23,7 @@ namespace ReactNativePSPDFKit
     /// </summary>
     public class PSPDFKitPackage : IReactPackage
     {
-        private PSPDFKitViewManger _pspdfkitViewManger = new PSPDFKitViewManger();
+        private readonly PSPDFKitViewManger _pspdfkitViewManger = new PSPDFKitViewManger();
 
         /// <summary>
         /// Creates the PSPDFKitModule native modules to register with the react

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitViewManager.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitViewManager.cs
@@ -1,8 +1,14 @@
-﻿using System;
+﻿//
+//  Copyright © 2018 PSPDFKit GmbH. All rights reserved.
+//
+//  THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY INTERNATIONAL COPYRIGHT LAW
+//  AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT.
+//  UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
+//  This notice may not be removed from this file.
+//
+
+using System;
 using System.Threading.Tasks;
-using PSPDFKit;
-using PSPDFKit.Document;
-using PSPDFKit.UI;
 using ReactNative.UIManager;
 using ReactNative.UIManager.Annotations;
 using Windows.Storage;

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/ReactNativePSPDFKit.csproj
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/ReactNativePSPDFKit.csproj
@@ -115,10 +115,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.1.5</Version>
+      <Version>6.0.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
-      <Version>3.0.0</Version>
+      <Version>4.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
       <Version>2.0.0</Version>


### PR DESCRIPTION
As a response to https://github.com/PSPDFKit/react-native/issues/112 an issue was found when not passing document from JS. I believe this should be an optional feature therefore this PR fixes this. 

No document will attempt to load by default if document is not present. 

In addition to this, some library alignment were made and copyrights updated. 