### PR TITLE
Fix local reference to package

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,8 +726,7 @@ pspdfkit repo online.
 -"react-native": "0.55.4",
 +"react-native": "0.53.0",
 "react-native-fs": "2.10.14",
--"react-native-pspdfkit": "file:../../",
-+"react-native-pspdfkit": "github:PSPDFKit/react-native",
+"react-native-pspdfkit": "file:../../",
 "react-native-windows": "0.53.0",
 "react-navigation": "^1.0.3"
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "prop-types": "*"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
As `prop-types` is it's own packages now, rather than being packages in `React` we have to depend on this also. This was not causing issues for none local references for some reason, but appeared when using the Catalog for windows. 