### PR TITLE
Windows FTS 

### DIFF
--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -22,95 +22,99 @@ import PSPDFKitView from "react-native-pspdfkit";
 
 var PSPDFKit = NativeModules.ReactPSPDFKit;
 var PSPDFKitLibrary = NativeModules.ReactPSPDFKitLibrary;
-var RNFS = require('react-native-fs');
+var RNFS = require("react-native-fs");
 
 var myLibraryCreated = false;
 
 const complexSearchConfiguration = {
-    searchString: "the",
-    excludeAnnotations: false,
-    excludeDocumentText: false,
-    matchExactPhrases: false,
-    maximumSearchResultsPerDocument: 0,
-    maximumSearchResultsTotal: 500,
-    maximumPreviewResultsPerDocument: 0,
-    maximumPreviewResultsTotal: 500,
-    generateTextPreviews: true,
-    previewRange: { position: 20, length: 120 }
-}
+  searchString: "the",
+  excludeAnnotations: false,
+  excludeDocumentText: false,
+  matchExactPhrases: false,
+  maximumSearchResultsPerDocument: 0,
+  maximumSearchResultsTotal: 500,
+  maximumPreviewResultsPerDocument: 0,
+  maximumPreviewResultsTotal: 500,
+  generateTextPreviews: true,
+  previewRange: { position: 20, length: 120 }
+};
 
 const simpleSearch = {
-    searchString: "the"
-}
+  searchString: "the"
+};
 
 var examples = [
-    {
-        name: "Open assets document",
-        description: "Open document from your project assets folder",
-        action: component => {
-            component.props.navigation.navigate("PdfView");
-        }
-    },
-    {
-        name: "Present a file from source",
-        description: "Open document from source",
-        action: component => {
-            component.props.navigation.navigate("PdfView");
-            // Present can only take files loaded in the Visual studio Project's Assets. Please use RNFS.
-            // See https://docs.microsoft.com/en-us/windows/uwp/files/file-access-permissions
-            var path = RNFS.MainBundlePath + "\\Assets\\pdf\\Business Report.pdf"
-            PSPDFKit.Present(path);
-        }
-    },
-    {
-        name: "Event Listeners",
-        description:
-            "Show how to use the listeners exposed by PSPDFKitView component.",
-        action: component => {
-            component.props.navigation.navigate("PdfViewListenersScreen");
-        }
-    },
-    {
-        name: "Programmatic Annotations",
-        description:
-            "Shows how to get and add new annotations using Instant JSON.",
-        action: component => {
-            component.props.navigation.navigate("PdfViewInstantJsonScreen");
-        }
-    },
-    {
-        name: "Index Full Text Search From Picker",
-        description:
-            "A simple full text search over a folder of the users choice.",
-        action: async component => {
-
-            await PSPDFKitLibrary.OpenLibrary("MyLibrary");
-            await PSPDFKitLibrary.EnqueueDocumentsInFolderPicker("MyLibrary");
-            alert("Searching Library for \"" + simpleSearch.searchString + "\". Please wait.");
-            PSPDFKitLibrary.SearchLibrary("MyLibrary", simpleSearch)
-                .then(result => {
-                    alert("Search : \n" + JSON.stringify(result));
-                })
-                .finally(() => PSPDFKitLibrary.DeleteAllLibraries());
-        }
-    },
-    {
-        name: "Index Full Text Search From Assets",
-        description:
-            "A simple full text search over the assets folder.",
-        action: async component => {
-            var path = RNFS.MainBundlePath + "\\Assets\\pdf";
-
-            await PSPDFKitLibrary.OpenLibrary("AssetsLibrary");
-            await PSPDFKitLibrary.EnqueueDocumentsInFolder("AssetsLibrary", path);
-            alert("Searching Library for \"" + complexSearchConfiguration.searchString + "\". Please wait.");
-            PSPDFKitLibrary.SearchLibrary("AssetsLibrary", complexSearchConfiguration)
-                .then(result => {
-                    alert("Search : \n" + JSON.stringify(result));
-                })
-                .finally(() => PSPDFKitLibrary.DeleteAllLibraries());
-        }
+  {
+    name: "Open assets document",
+    description: "Open document from your project assets folder",
+    action: component => {
+      component.props.navigation.navigate("PdfView");
     }
+  },
+  {
+    name: "Present a file from source",
+    description: "Open document from source",
+    action: component => {
+      component.props.navigation.navigate("PdfView");
+      // Present can only take files loaded in the Visual studio Project's Assets. Please use RNFS.
+      // See https://docs.microsoft.com/en-us/windows/uwp/files/file-access-permissions
+      var path = RNFS.MainBundlePath + "\\Assets\\pdf\\Business Report.pdf";
+      PSPDFKit.Present(path);
+    }
+  },
+  {
+    name: "Event Listeners",
+    description:
+      "Show how to use the listeners exposed by PSPDFKitView component.",
+    action: component => {
+      component.props.navigation.navigate("PdfViewListenersScreen");
+    }
+  },
+  {
+    name: "Programmatic Annotations",
+    description: "Shows how to get and add new annotations using Instant JSON.",
+    action: component => {
+      component.props.navigation.navigate("PdfViewInstantJsonScreen");
+    }
+  },
+  {
+    name: "Index Full Text Search From Picker",
+    description: "A simple full text search over a folder of the users choice.",
+    action: async component => {
+      await PSPDFKitLibrary.OpenLibrary("MyLibrary");
+      await PSPDFKitLibrary.EnqueueDocumentsInFolderPicker("MyLibrary");
+      alert(
+        'Searching Library for "' +
+          simpleSearch.searchString +
+          '". Please wait.'
+      );
+      PSPDFKitLibrary.SearchLibrary("MyLibrary", simpleSearch)
+        .then(result => {
+          alert("Search : \n" + JSON.stringify(result));
+        })
+        .finally(() => PSPDFKitLibrary.DeleteAllLibraries());
+    }
+  },
+  {
+    name: "Index Full Text Search From Assets",
+    description: "A simple full text search over the assets folder.",
+    action: async component => {
+      var path = RNFS.MainBundlePath + "\\Assets\\pdf";
+
+      await PSPDFKitLibrary.OpenLibrary("AssetsLibrary");
+      await PSPDFKitLibrary.EnqueueDocumentsInFolder("AssetsLibrary", path);
+      alert(
+        'Searching Library for "' +
+          complexSearchConfiguration.searchString +
+          '". Please wait.'
+      );
+      PSPDFKitLibrary.SearchLibrary("AssetsLibrary", complexSearchConfiguration)
+        .then(result => {
+          alert("Search : \n" + JSON.stringify(result));
+        })
+        .finally(() => PSPDFKitLibrary.DeleteAllLibraries());
+    }
+  }
 ];
 
 class CatalogScreen extends Component<{}> {

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -23,38 +23,52 @@ import PSPDFKitView from "react-native-pspdfkit";
 var PSPDFKit = NativeModules.ReactPSPDFKit;
 
 var examples = [
-  {
-    name: "Open assets document",
-    description: "Open document from your project assets folder",
-    action: component => {
-      component.props.navigation.navigate("PdfView");
+    {
+        name: "Open assets document",
+        description: "Open document from your project assets folder",
+        action: component => {
+            component.props.navigation.navigate("PdfView");
+        }
+    },
+    {
+        name: "Present a file from source",
+        description: "Open document from source",
+        action: component => {
+            component.props.navigation.navigate("PdfView");
+            // Present can only take files loaded in the Visual studio Project's Assets.
+            // See https://docs.microsoft.com/en-us/windows/uwp/files/file-access-permissions
+            PSPDFKit.Present("ms-appx:///Assets/pdf/Business Report.pdf");
+        }
+    },
+    {
+        name: "Event Listeners",
+        description:
+            "Show how to use the listeners exposed by PSPDFKitView component.",
+        action: component => {
+            component.props.navigation.navigate("PdfViewListenersScreen");
+        }
+    },
+    {
+        name: "Programmatic Annotations",
+        description:
+            "Shows how to get and add new annotations using Instant JSON.",
+        action: component => {
+            component.props.navigation.navigate("PdfViewInstantJsonScreen");
+        }
+    },
+    {
+        name: "Index Full Text Search",
+        description:
+            "A simple full text search over a folder of the users choice.",
+        action: component => {
+            PSPDFKit.OpenLibrary("MyLibrary")
+                .then(() => {
+                    PSPDFKit.SearchLibrary("pspdfkit")
+                        .then(result =>
+                            alert("We found strings : \n" + JSON.stringify(result)))
+                })
+        }
     }
-  },
-  {
-    name: "Present a file from source",
-    description: "Open document from source",
-    action: component => {
-      component.props.navigation.navigate("PdfView");
-      // Present can only take files loaded in the Visual studio Project's Assets.
-      // See https://docs.microsoft.com/en-us/windows/uwp/files/file-access-permissions
-      PSPDFKit.Present("ms-appx:///Assets/pdf/Business Report.pdf");
-    }
-  },
-  {
-    name: "Event Listeners",
-    description:
-      "Show how to use the listeners exposed by PSPDFKitView component.",
-    action: component => {
-      component.props.navigation.navigate("PdfViewListenersScreen");
-    }
-  },
-  {
-    name: "Programmatic Annotations",
-    description: "Shows how to get and add new annotations using Instant JSON.",
-    action: component => {
-      component.props.navigation.navigate("PdfViewInstantJsonScreen");
-    }
-  }
 ];
 
 class CatalogScreen extends Component<{}> {

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -83,9 +83,12 @@ var examples = [
         description:
             "A simple full text search over a folder of the users choice.",
         action: async component => {
-            await PSPDFKitLibrary.OpenLibraryPicker("MyLibrary");
+
+            await PSPDFKitLibrary.OpenLibrary("MyLibrary");
+            await PSPDFKitLibrary.EnqueueDocumentsInFolderPicker("MyLibrary");
+            alert("Searching Library for \"" + simpleSearch.searchString + "\". Please wait.");
             PSPDFKitLibrary.SearchLibrary("MyLibrary", simpleSearch)
-                .then(async result => {
+                .then(result => {
                     alert("Search : \n" + JSON.stringify(result));
                 })
                 .finally(() => PSPDFKitLibrary.DeleteAllLibraries());
@@ -98,9 +101,11 @@ var examples = [
         action: async component => {
             var path = RNFS.MainBundlePath + "\\Assets\\pdf";
 
-            await PSPDFKitLibrary.OpenLibrary("AssetsLibrary", path);
+            await PSPDFKitLibrary.OpenLibrary("AssetsLibrary");
+            await PSPDFKitLibrary.EnqueueDocumentsInFolder("AssetsLibrary", path);
+            alert("Searching Library for \"" + complexSearchConfiguration.searchString + "\". Please wait.");
             PSPDFKitLibrary.SearchLibrary("AssetsLibrary", complexSearchConfiguration)
-                .then(async result => {
+                .then(result => {
                     alert("Search : \n" + JSON.stringify(result));
                 })
                 .finally(() => PSPDFKitLibrary.DeleteAllLibraries());

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -23,6 +23,23 @@ import PSPDFKitView from "react-native-pspdfkit";
 var PSPDFKit = NativeModules.ReactPSPDFKit;
 var myLibraryCreated = false;
 
+const complexSearchConfiguration = {
+    searchString: "pspdfkit",
+    excludeAnnotations: false,
+    excludeDocumentText: false,
+    matchExactPhrases: false,
+    maximumSearchResultsPerDocument: 0,
+    maximumSearchResultsTotal: 500,
+    maximumPreviewResultsPerDocument: 0,
+    maximumPreviewResultsTotal: 500,
+    generateTextPreviews: true,
+    previewRange: { position: 20, length: 120 }
+}
+
+const simpleSearch = {
+    searchString: "pspdfkit"
+}
+
 var examples = [
     {
         name: "Open assets document",
@@ -63,16 +80,14 @@ var examples = [
             "A simple full text search over a folder of the users choice.",
         action: component => {
             if (myLibraryCreated) {
-                PSPDFKit.SearchLibrary("MyLibrary", "pspdfkit")
+                PSPDFKit.SearchLibrary("MyLibrary", simpleSearch)
                     .then(result => alert("Search : \n" + JSON.stringify(result)))
             } else {
                 PSPDFKit.OpenLibraryPicker("MyLibrary")
                     .then(() => {
                         myLibraryCreated = true;
-                        PSPDFKit.SearchLibrary("MyLibrary", "pspdfkit")
+                        PSPDFKit.SearchLibrary("MyLibrary", complexSearchConfiguration)
                             .then(result => alert("Search : \n" + JSON.stringify(result)))
-                        PSPDFKit.SearchLibraryGeneratePreviews("MyLibrary", "pspdfkit")
-                            .then(result => alert("Previews : \n" + JSON.stringify(result)))
                     })
             }
         }

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -21,6 +21,7 @@ import { StackNavigator } from "react-navigation";
 import PSPDFKitView from "react-native-pspdfkit";
 
 var PSPDFKit = NativeModules.ReactPSPDFKit;
+var myLibraryCreated = false;
 
 var examples = [
     {
@@ -61,12 +62,19 @@ var examples = [
         description:
             "A simple full text search over a folder of the users choice.",
         action: component => {
-            PSPDFKit.OpenLibrary("MyLibrary")
-                .then(() => {
-                    PSPDFKit.SearchLibrary("pspdfkit")
-                        .then(result =>
-                            alert("We found strings : \n" + JSON.stringify(result)))
-                })
+            if (myLibraryCreated) {
+                PSPDFKit.SearchLibrary("MyLibrary", "pspdfkit")
+                    .then(result => alert("Search : \n" + JSON.stringify(result)))
+            } else {
+                PSPDFKit.OpenLibraryPicker("MyLibrary")
+                    .then(() => {
+                        myLibraryCreated = true;
+                        PSPDFKit.SearchLibrary("MyLibrary", "pspdfkit")
+                            .then(result => alert("Search : \n" + JSON.stringify(result)))
+                        PSPDFKit.SearchLibraryGeneratePreviews("MyLibrary", "pspdfkit")
+                            .then(result => alert("Previews : \n" + JSON.stringify(result)))
+                    })
+            }
         }
     }
 ];

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -21,6 +21,7 @@ import { StackNavigator } from "react-navigation";
 import PSPDFKitView from "react-native-pspdfkit";
 
 var PSPDFKit = NativeModules.ReactPSPDFKit;
+var PSPDFKitLibrary = NativeModules.ReactPSPDFKitLibrary;
 var RNFS = require('react-native-fs');
 
 var myLibraryCreated = false;
@@ -82,12 +83,13 @@ var examples = [
         description:
             "A simple full text search over a folder of the users choice.",
         action: component => {
-            PSPDFKit.DeleteAllLibraries();
-
-            PSPDFKit.OpenLibraryPicker("MyLibrary")
+            PSPDFKitLibrary.OpenLibraryPicker("MyLibrary")
                 .then(() => {
-                    PSPDFKit.SearchLibrary("MyLibrary", simpleSearch)
-                        .then(result => alert("Search : \n" + JSON.stringify(result)))
+                    PSPDFKitLibrary.SearchLibrary("MyLibrary", simpleSearch)
+                        .then(async result => {
+                            alert("Search : \n" + JSON.stringify(result));
+                            await PSPDFKitLibrary.DeleteAllLibraries();
+                        });
                 });
         }
     },
@@ -96,14 +98,16 @@ var examples = [
         description:
             "A simple full text search over the assets folder.",
         action: component => {
-            PSPDFKit.DeleteAllLibraries();
+            var path = RNFS.MainBundlePath + "\\Assets\\pdf";
 
-            var path = RNFS.MainBundlePath + "\\Assets\\pdf"
-            PSPDFKit.OpenLibrary("AssetsLibrary", path)
+            PSPDFKitLibrary.OpenLibrary("AssetsLibrary", path)
                 .then(() => {
-                    PSPDFKit.SearchLibrary("AssetsLibrary", complexSearchConfiguration)
-                        .then(result => alert("Search : \n" + JSON.stringify(result)))
-                })
+                    PSPDFKitLibrary.SearchLibrary("AssetsLibrary", complexSearchConfiguration)
+                        .then(async result => {
+                            alert("Search : \n" + JSON.stringify(result));
+                            await PSPDFKitLibrary.DeleteAllLibraries();
+                        });
+                });
         }
     }
 ];

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -21,10 +21,12 @@ import { StackNavigator } from "react-navigation";
 import PSPDFKitView from "react-native-pspdfkit";
 
 var PSPDFKit = NativeModules.ReactPSPDFKit;
+var RNFS = require('react-native-fs');
+
 var myLibraryCreated = false;
 
 const complexSearchConfiguration = {
-    searchString: "pspdfkit",
+    searchString: "the",
     excludeAnnotations: false,
     excludeDocumentText: false,
     matchExactPhrases: false,
@@ -37,7 +39,7 @@ const complexSearchConfiguration = {
 }
 
 const simpleSearch = {
-    searchString: "pspdfkit"
+    searchString: "the"
 }
 
 var examples = [
@@ -53,9 +55,10 @@ var examples = [
         description: "Open document from source",
         action: component => {
             component.props.navigation.navigate("PdfView");
-            // Present can only take files loaded in the Visual studio Project's Assets.
+            // Present can only take files loaded in the Visual studio Project's Assets. Please use RNFS.
             // See https://docs.microsoft.com/en-us/windows/uwp/files/file-access-permissions
-            PSPDFKit.Present("ms-appx:///Assets/pdf/Business Report.pdf");
+            var path = RNFS.MainBundlePath + "\\Assets\\pdf\\Business Report.pdf"
+            PSPDFKit.Present(path);
         }
     },
     {
@@ -75,21 +78,32 @@ var examples = [
         }
     },
     {
-        name: "Index Full Text Search",
+        name: "Index Full Text Search From Picker",
         description:
             "A simple full text search over a folder of the users choice.",
         action: component => {
-            if (myLibraryCreated) {
-                PSPDFKit.SearchLibrary("MyLibrary", simpleSearch)
-                    .then(result => alert("Search : \n" + JSON.stringify(result)))
-            } else {
-                PSPDFKit.OpenLibraryPicker("MyLibrary")
-                    .then(() => {
-                        myLibraryCreated = true;
-                        PSPDFKit.SearchLibrary("MyLibrary", complexSearchConfiguration)
-                            .then(result => alert("Search : \n" + JSON.stringify(result)))
-                    })
-            }
+            PSPDFKit.DeleteAllLibraries();
+
+            PSPDFKit.OpenLibraryPicker("MyLibrary")
+                .then(() => {
+                    PSPDFKit.SearchLibrary("MyLibrary", simpleSearch)
+                        .then(result => alert("Search : \n" + JSON.stringify(result)))
+                });
+        }
+    },
+    {
+        name: "Index Full Text Search From Assets",
+        description:
+            "A simple full text search over the assets folder.",
+        action: component => {
+            PSPDFKit.DeleteAllLibraries();
+
+            var path = RNFS.MainBundlePath + "\\Assets\\pdf"
+            PSPDFKit.OpenLibrary("AssetsLibrary", path)
+                .then(() => {
+                    PSPDFKit.SearchLibrary("AssetsLibrary", complexSearchConfiguration)
+                        .then(result => alert("Search : \n" + JSON.stringify(result)))
+                })
         }
     }
 ];

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -24,8 +24,6 @@ var PSPDFKit = NativeModules.ReactPSPDFKit;
 var PSPDFKitLibrary = NativeModules.ReactPSPDFKitLibrary;
 var RNFS = require("react-native-fs");
 
-var myLibraryCreated = false;
-
 const complexSearchConfiguration = {
   searchString: "the",
   excludeAnnotations: false,

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -82,32 +82,28 @@ var examples = [
         name: "Index Full Text Search From Picker",
         description:
             "A simple full text search over a folder of the users choice.",
-        action: component => {
-            PSPDFKitLibrary.OpenLibraryPicker("MyLibrary")
-                .then(() => {
-                    PSPDFKitLibrary.SearchLibrary("MyLibrary", simpleSearch)
-                        .then(async result => {
-                            alert("Search : \n" + JSON.stringify(result));
-                            await PSPDFKitLibrary.DeleteAllLibraries();
-                        });
-                });
+        action: async component => {
+            await PSPDFKitLibrary.OpenLibraryPicker("MyLibrary");
+            PSPDFKitLibrary.SearchLibrary("MyLibrary", simpleSearch)
+                .then(async result => {
+                    alert("Search : \n" + JSON.stringify(result));
+                })
+                .finally(() => PSPDFKitLibrary.DeleteAllLibraries());
         }
     },
     {
         name: "Index Full Text Search From Assets",
         description:
             "A simple full text search over the assets folder.",
-        action: component => {
+        action: async component => {
             var path = RNFS.MainBundlePath + "\\Assets\\pdf";
 
-            PSPDFKitLibrary.OpenLibrary("AssetsLibrary", path)
-                .then(() => {
-                    PSPDFKitLibrary.SearchLibrary("AssetsLibrary", complexSearchConfiguration)
-                        .then(async result => {
-                            alert("Search : \n" + JSON.stringify(result));
-                            await PSPDFKitLibrary.DeleteAllLibraries();
-                        });
-                });
+            await PSPDFKitLibrary.OpenLibrary("AssetsLibrary", path);
+            PSPDFKitLibrary.SearchLibrary("AssetsLibrary", complexSearchConfiguration)
+                .then(async result => {
+                    alert("Search : \n" + JSON.stringify(result));
+                })
+                .finally(() => PSPDFKitLibrary.DeleteAllLibraries());
         }
     }
 ];

--- a/samples/Catalog/windows/Catalog.sln
+++ b/samples/Catalog/windows/Catalog.sln
@@ -16,6 +16,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReactNativePSPDFKit", "..\node_modules\react-native-pspdfkit\windows\ReactNativePSPDFKit\ReactNativePSPDFKit\ReactNativePSPDFKit.csproj", "{475F630C-9EA0-4CD2-823A-0BB2DBB4778A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RNFS", "..\node_modules\react-native-fs\windows\RNFS\RNFS.csproj", "{746610D0-8693-11E7-A20D-BF83F7366778}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\node_modules\react-native-windows\ReactWindows\ReactNative.Shared\ReactNative.Shared.projitems*{c7673ad5-e3aa-468c-a5fd-fa38154e205c}*SharedItemsImports = 4
@@ -250,6 +252,43 @@ Global
 		{475F630C-9EA0-4CD2-823A-0BB2DBB4778A}.ReleaseBundle|x64.Build.0 = Release|x64
 		{475F630C-9EA0-4CD2-823A-0BB2DBB4778A}.ReleaseBundle|x86.ActiveCfg = Release|x86
 		{475F630C-9EA0-4CD2-823A-0BB2DBB4778A}.ReleaseBundle|x86.Build.0 = Release|x86
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Debug|ARM.ActiveCfg = Debug|ARM
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Debug|ARM.Build.0 = Debug|ARM
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Debug|x64.ActiveCfg = Debug|x64
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Debug|x64.Build.0 = Debug|x64
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Debug|x86.ActiveCfg = Debug|x86
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Debug|x86.Build.0 = Debug|x86
+		{746610D0-8693-11E7-A20D-BF83F7366778}.DebugBundle|Any CPU.ActiveCfg = Release|x64
+		{746610D0-8693-11E7-A20D-BF83F7366778}.DebugBundle|Any CPU.Build.0 = Release|x64
+		{746610D0-8693-11E7-A20D-BF83F7366778}.DebugBundle|ARM.ActiveCfg = Debug|ARM
+		{746610D0-8693-11E7-A20D-BF83F7366778}.DebugBundle|ARM.Build.0 = Debug|ARM
+		{746610D0-8693-11E7-A20D-BF83F7366778}.DebugBundle|x64.ActiveCfg = Debug|x64
+		{746610D0-8693-11E7-A20D-BF83F7366778}.DebugBundle|x64.Build.0 = Debug|x64
+		{746610D0-8693-11E7-A20D-BF83F7366778}.DebugBundle|x86.ActiveCfg = Debug|x86
+		{746610D0-8693-11E7-A20D-BF83F7366778}.DebugBundle|x86.Build.0 = Debug|x86
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Development|Any CPU.ActiveCfg = Development|x86
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Development|ARM.ActiveCfg = Development|ARM
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Development|ARM.Build.0 = Development|ARM
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Development|x64.ActiveCfg = Development|x64
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Development|x64.Build.0 = Development|x64
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Development|x86.ActiveCfg = Development|x86
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Development|x86.Build.0 = Development|x86
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Release|Any CPU.ActiveCfg = Release|x86
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Release|ARM.ActiveCfg = Release|ARM
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Release|ARM.Build.0 = Release|ARM
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Release|x64.ActiveCfg = Release|x64
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Release|x64.Build.0 = Release|x64
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Release|x86.ActiveCfg = Release|x86
+		{746610D0-8693-11E7-A20D-BF83F7366778}.Release|x86.Build.0 = Release|x86
+		{746610D0-8693-11E7-A20D-BF83F7366778}.ReleaseBundle|Any CPU.ActiveCfg = Release|x64
+		{746610D0-8693-11E7-A20D-BF83F7366778}.ReleaseBundle|Any CPU.Build.0 = Release|x64
+		{746610D0-8693-11E7-A20D-BF83F7366778}.ReleaseBundle|ARM.ActiveCfg = Release|ARM
+		{746610D0-8693-11E7-A20D-BF83F7366778}.ReleaseBundle|ARM.Build.0 = Release|ARM
+		{746610D0-8693-11E7-A20D-BF83F7366778}.ReleaseBundle|x64.ActiveCfg = Release|x64
+		{746610D0-8693-11E7-A20D-BF83F7366778}.ReleaseBundle|x64.Build.0 = Release|x64
+		{746610D0-8693-11E7-A20D-BF83F7366778}.ReleaseBundle|x86.ActiveCfg = Release|x86
+		{746610D0-8693-11E7-A20D-BF83F7366778}.ReleaseBundle|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/Catalog/windows/Catalog/Catalog.csproj
+++ b/samples/Catalog/windows/Catalog/Catalog.csproj
@@ -209,6 +209,10 @@
     </ApplicationDefinition>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\node_modules\react-native-fs\windows\RNFS\RNFS.csproj">
+      <Project>{746610D0-8693-11E7-A20D-BF83F7366778}</Project>
+      <Name>RNFS</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\node_modules\react-native-pspdfkit\windows\ReactNativePSPDFKit\ReactNativePSPDFKit\ReactNativePSPDFKit.csproj">
       <Project>{475f630c-9ea0-4cd2-823a-0bb2dbb4778a}</Project>
       <Name>ReactNativePSPDFKit</Name>

--- a/samples/Catalog/windows/Catalog/Catalog.csproj
+++ b/samples/Catalog/windows/Catalog/Catalog.csproj
@@ -234,7 +234,7 @@
     <SDKReference Include="Microsoft.VCLibs, Version=14.0">
       <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
     </SDKReference>
-    <SDKReference Include="PSPDFKitSDK, Version=1.6.0">
+    <SDKReference Include="PSPDFKitSDK, Version=1.6.1">
       <Name>PSPDFKit for UWP</Name>
     </SDKReference>
   </ItemGroup>

--- a/samples/Catalog/windows/Catalog/MainReactNativeHost.cs
+++ b/samples/Catalog/windows/Catalog/MainReactNativeHost.cs
@@ -2,7 +2,7 @@ using ReactNative;
 using ReactNative.Modules.Core;
 using ReactNative.Shell;
 using System.Collections.Generic;
-using Windows.UI.Core;
+using RNFS;
 
 namespace Catalog
 {
@@ -26,6 +26,7 @@ namespace Catalog
         {
             new MainReactPackage(),
             new ReactNativePSPDFKit.PSPDFKitPackage(),
+            new RNFSPackage()
         };
     }
 }

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/Events/PdfViewAnnotationChangedEvent.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/Events/PdfViewAnnotationChangedEvent.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json.Linq;
 using PSPDFKit.Pdf.Annotation;
 using ReactNative.UIManager.Events;
 

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/Events/PdfViewDataReturnedEvent.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/Events/PdfViewDataReturnedEvent.cs
@@ -46,7 +46,7 @@ namespace ReactNativePSPDFKit.Events
             _payload.Add("error", errorMessage);
         }
 
-        public override String EventName => EVENT_NAME;
+        public override string EventName => EVENT_NAME;
 
         public override void Dispatch(RCTEventEmitter eventEmitter)
         {

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/Events/PdfViewDocumentSaveFailedEvent.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/Events/PdfViewDocumentSaveFailedEvent.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json.Linq;
 using ReactNative.UIManager.Events;
 
 namespace ReactNativePSPDFKit.Events

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/Events/PdfViewDocumentSavedEvent.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/Events/PdfViewDocumentSavedEvent.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
-using ReactNative.UIManager.Events;
+﻿using ReactNative.UIManager.Events;
 
 namespace ReactNativePSPDFKit.Events
 {

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/JsonUtils.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/JsonUtils.cs
@@ -1,12 +1,72 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
+using PSPDFKit.Search;
 using PSPDFKitFoundation;
 using PSPDFKitFoundation.Search;
+using PSPDFKitNative;
 
 namespace ReactNativePSPDFKit
 {
     static class JsonUtils
     {
+        public static LibraryQuery ToLibraryQuery(JObject libraryQueryJson)
+        {
+            var libraryQuery = new LibraryQuery(libraryQueryJson.Value<string>("searchString"));
+
+            if (libraryQueryJson.ContainsKey("excludeAnnotations"))
+            {
+                libraryQuery.ExcludeAnnotations = libraryQueryJson.Value<bool>("excludeAnnotations");
+            }
+
+            if (libraryQueryJson.ContainsKey("excludeDocumentText"))
+            {
+                libraryQuery.ExcludeDocumentText = libraryQueryJson.Value<bool>("excludeDocumentText");
+            }
+
+            if (libraryQueryJson.ContainsKey("matchExactPhrases"))
+            {
+                libraryQuery.MatchExactPhrases = libraryQueryJson.Value<bool>("matchExactPhrases");
+            }
+
+            if (libraryQueryJson.ContainsKey("maximumSearchResultsPerDocument"))
+            {
+                libraryQuery.MaximumSearchResultsPerDocument = libraryQueryJson.Value<int>("maximumSearchResultsPerDocument");
+            }
+
+            if (libraryQueryJson.ContainsKey("maximumSearchResultsTotal"))
+            {
+                libraryQuery.MaximumSearchResultsTotal = libraryQueryJson.Value<int>("maximumSearchResultsTotal");
+            }
+
+
+            if (libraryQueryJson.ContainsKey("maximumPreviewResultsPerDocument"))
+            {
+                libraryQuery.MaximumPreviewResultsPerDocument = libraryQueryJson.Value<int>("maximumPreviewResultsPerDocument");
+            }
+
+            if (libraryQueryJson.ContainsKey("maximumPreviewResultsTotal"))
+            {
+                libraryQuery.MaximumPreviewResultsTotal = libraryQueryJson.Value<int>("maximumPreviewResultsTotal");
+            }
+
+            if (libraryQueryJson.ContainsKey("generateTextPreviews"))
+            {
+                libraryQuery.GenerateTextPreviews = libraryQueryJson.Value<bool>("generateTextPreviews");
+            }
+
+            if (libraryQueryJson.ContainsKey("generateTextPreviews"))
+            {
+                libraryQuery.GenerateTextPreviews = libraryQueryJson.Value<bool>("generateTextPreviews");
+            }
+
+            if (libraryQueryJson.ContainsKey("previewRange"))
+            {
+                libraryQuery.PreviewRange = ToRange(libraryQueryJson.GetValue("previewRange"));
+            }
+
+            return libraryQuery;
+        }
+
         internal static JToken PreviewResultsToJson(IEnumerable<LibraryPreviewResult> previewResults)
         {
             var previewResultsJson = new JArray();
@@ -53,6 +113,11 @@ namespace ReactNativePSPDFKit
                 { "position", range.Position},
                 { "length", range.Length}
             };
+        }
+
+        private static IRange ToRange(JToken rangeJson)
+        {
+            return new Range(rangeJson.Value<int>("postion"), rangeJson.Value<int>("length"));
         }
 
         private static JArray LibraryQueryReultToJson(LibraryQueryResult libraryQueryResult)

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/JsonUtils.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/JsonUtils.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using PSPDFKitFoundation;
+using PSPDFKitFoundation.Search;
+
+namespace ReactNativePSPDFKit
+{
+    static class JsonUtils
+    {
+        internal static JToken PreviewResultsToJson(IEnumerable<LibraryPreviewResult> previewResults)
+        {
+            var previewResultsJson = new JArray();
+            foreach (var documentQueryResult in previewResults)
+            {
+                var result = new JObject
+                {
+                    {"uid", documentQueryResult.Uid},
+                    {"pageIndex", documentQueryResult.PageIndex},
+                    {"previewText", documentQueryResult.PreviewText},
+                    {"rangeInText", RangeToJson(documentQueryResult.RangeInText)},
+                    {"rangeInPreviewText", RangeToJson(documentQueryResult.RangeInPreviewText)},
+                    {"annotationId", documentQueryResult.AnnotationId}
+                };
+
+                previewResultsJson.Add(result);
+            }
+
+            return previewResultsJson;
+        }
+
+        internal static JToken SearchResultsToJson(IDictionary<string, LibraryQueryResult> queryResults)
+        {
+            var queryResultsJson = new JArray();
+            foreach (var documentQueryResult in queryResults)
+            {
+                var result = new JObject
+                {
+                    {"uid", documentQueryResult.Key},
+                    {"pageResults", LibraryQueryReultToJson(documentQueryResult.Value)}
+                };
+
+
+                queryResultsJson.Add(result);
+            }
+
+            return queryResultsJson;
+        }
+
+        private static JToken RangeToJson(IRange range)
+        {
+            return new JObject
+            {
+                { "position", range.Position},
+                { "length", range.Length}
+            };
+        }
+
+        private static JArray LibraryQueryReultToJson(LibraryQueryResult libraryQueryResult)
+        {
+            var pageNumbersJson = new JArray();
+
+            foreach (var pageNumber in libraryQueryResult.PageResults)
+            {
+                pageNumbersJson.Add(pageNumber);
+            }
+
+            return pageNumbersJson;
+        }
+    }
+}

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/LibraryModule.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/LibraryModule.cs
@@ -1,0 +1,242 @@
+﻿//
+//  Copyright © 2018 PSPDFKit GmbH. All rights reserved.
+//
+//  THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY INTERNATIONAL COPYRIGHT LAW
+//  AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT.
+//  UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
+//  This notice may not be removed from this file.
+//
+
+using PSPDFKit;
+using PSPDFKit.Search;
+using PSPDFKitFoundation.Search;
+using ReactNative.Bridge;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.Core;
+using Windows.Storage;
+using Microsoft.Toolkit.Uwp.Helpers;
+using Newtonsoft.Json.Linq;
+
+namespace ReactNativePSPDFKit
+{
+    /// <summary>
+    /// A bridge to the PSPDFKit SDK.
+    /// </summary>
+    class LibraryModule : ReactContextNativeModuleBase
+    {
+        public LibraryModule(ReactContext reactContext, string license) : base(reactContext)
+        {
+            Sdk.Initialize(license);
+        }
+
+        /// <summary>
+        /// Open a search library from a ms path.
+        /// Multiple libraries maybe open at once. Use the name to reference each library.
+        /// Promise will resolve with true if library is opened. Promise will reject if folder is inaccessible.
+        /// <param name="libraryName">Name to give the library</param>
+        /// <param name="uri">A path to a folder to index. The application must have permission to the path.</param>
+        /// See https://docs.microsoft.com/en-us/windows/uwp/files/file-access-permissions
+        /// </summary>
+        [ReactMethod]
+        public async void OpenLibrary(string libraryName, string path, IPromise promise)
+        {
+            await CoreApplication.MainView.Dispatcher.AwaitableRunAsync(async () =>
+            {
+                try
+                {
+                    var storageFolder = await StorageFolder.GetFolderFromPathAsync(path);
+
+                    using (var library = await Library.OpenLibraryAsync(libraryName))
+                    {
+                        // Queue up the PDFs in the folder for indexing.
+                        await library.EnqueueDocumentsInFolderAsync(storageFolder);
+                    }
+
+                    promise.Resolve(true);
+                }
+                catch (Exception e)
+                {
+                    promise.Reject(e);
+                }
+            });
+        }
+
+        /// <summary>
+        /// Open a search library with the use of a folder picker.
+        /// Multiple libraries maybe open at once. Use the name to reference each library.
+        /// Promise will resolve with true if library is opened. Promise will reject if folder is inaccessible.
+        /// <param name="libraryName">Name to give the library</param>
+        /// </summary>
+        [ReactMethod]
+        public async void OpenLibraryPicker(string libraryName, IPromise promise)
+        {
+            await CoreApplication.MainView.Dispatcher.AwaitableRunAsync(async () =>
+            {
+                try
+                {
+                    // Allow the user to choose a folder to index.
+                    var folderPicker = new Windows.Storage.Pickers.FolderPicker
+                    {
+                        SuggestedStartLocation = Windows.Storage.Pickers.PickerLocationId.Desktop
+                    };
+                    folderPicker.FileTypeFilter.Add("*");
+
+                    var folder = await folderPicker.PickSingleFolderAsync();
+                    if (folder != null)
+                    {
+                        using (var library = await Library.OpenLibraryAsync(libraryName))
+                        {
+                            // Queue up the PDFs in the folder for indexing.
+                            await library.EnqueueDocumentsInFolderAsync(folder);
+                        }
+                        promise.Resolve(true);
+                    }
+                    else
+                    {
+                        promise.Reject(new System.IO.FileNotFoundException("Folder not accessible"));
+                    }
+                }
+                catch (Exception e)
+                {
+                    promise.Reject(e);
+                }
+            });
+        }
+
+        /// <summary>
+        /// Search a given library for the searchTerm and provide a promise
+        /// to retreive the page indexes of found instances.
+        /// 
+        /// Json return example
+        /// [
+        ///     {
+        ///         "uid": "{2B94FFD0-F846-4902-8A11-75C3D1E5B2A3}/default.pdf",
+        ///         "pageResults": [ 2 ]
+        ///     }
+        /// ]
+        /// or if previews are generated.
+        /// [
+        ///     {
+        ///         "uid": "{2B94FFD0-F846-4902-8A11-75C3D1E5B2A3}/default.pdf",
+        ///         "pageIndex": 2,
+        ///         "previewText": "example in PSPDFKit.",
+        ///         "rangeInText": {
+        ///             "position": 27,
+        ///             "length": 8
+        ///         },
+        ///         "rangeInPreviewText": {
+        ///             "position": 11,
+        ///             "length": 8
+        ///         },
+        ///         "annotationId": 55
+        ///     },
+        /// ]
+        /// 
+        /// </summary>
+        /// <param name="libraryName">Name of library to search.</param>
+        /// <param name="searchLibraryQuery">Configuration of query </param>
+        /// Example of configuration. All Items except search string are optional.
+        /// const libraryConfiguration = {
+        ///     searchString: "pspdfkit",
+        ///     excludeAnnotations: false,
+        ///     excludeDocumentText: false,
+        ///     matchExactPhrases: false,
+        ///     maximumSearchResultsPerDocument: 0,
+        ///     maximumSearchResultsTotal: 500,
+        ///     maximumPreviewResultsPerDocument: 0,
+        ///     maximumPreviewResultsTotal: 500,
+        ///     generateTextPreviews: true,
+        ///     previewRange: { position: 20, length: 120 }
+        /// }
+        [ReactMethod]
+        public async void SearchLibrary(string libraryName, JObject searchLibraryQuery, IPromise promise)
+        {
+            await CoreApplication.MainView.Dispatcher.AwaitableRunAsync(async () =>
+            {
+                JToken resultJson = null;
+                using (var library = await Library.OpenLibraryAsync(libraryName))
+                {
+                    await library.WaitForAllIndexingTasksToFinishAsync();
+
+                    var libraryQuery = JsonUtils.ToLibraryQuery(searchLibraryQuery);
+
+                    TaskCompletionSource<IList<LibraryPreviewResult>> previewsFromHandlerTcs = null;
+                    TaskCompletionSource<IDictionary<string, LibraryQueryResult>> resultsFromHandlerTcs = null;
+                    if (libraryQuery.GenerateTextPreviews)
+                    {
+                        previewsFromHandlerTcs = GetPreviewCompleteTcs(library);
+                    }
+                    else
+                    {
+                        resultsFromHandlerTcs = GetSearchCompleteTcs(library);
+                    }
+
+                    // We can do the searching in the background as the callbacks will receive the results.
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+                    library.SearchAsync(libraryQuery);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+
+                    if (previewsFromHandlerTcs != null)
+                    {
+                        var previewResults = await previewsFromHandlerTcs.Task;
+                        resultJson = JsonUtils.PreviewResultsToJson(previewResults);
+                    }
+
+                    if (resultsFromHandlerTcs != null)
+                    {
+                        var resultsFromHandler = await resultsFromHandlerTcs.Task;
+                        resultJson = JsonUtils.SearchResultsToJson(resultsFromHandler);
+                    }
+                }
+                promise.Resolve(resultJson);
+            });
+        }
+
+        [ReactMethod]
+        public async void DeleteAllLibraries(IPromise promise)
+        {
+            await CoreApplication.MainView.Dispatcher.AwaitableRunAsync(async () =>
+            {
+                await Library.DeleteAllLibrariesAsync();
+            });
+
+            promise.Resolve(null);
+        }
+
+
+        private static TaskCompletionSource<IDictionary<string, LibraryQueryResult>> GetSearchCompleteTcs(Library library)
+        {
+            var resultsFromHandlerTcs = new TaskCompletionSource<IDictionary<string, LibraryQueryResult>>();
+            void SearchHandler(object sender, IDictionary<string, LibraryQueryResult> args)
+            {
+                library.OnSearchComplete -= SearchHandler;
+                resultsFromHandlerTcs.SetResult(args);
+            }
+
+            library.OnSearchComplete += SearchHandler;
+
+            return resultsFromHandlerTcs;
+        }
+
+        private static TaskCompletionSource<IList<LibraryPreviewResult>> GetPreviewCompleteTcs(Library library)
+        {
+            var previewsFromHandlerTcs = new TaskCompletionSource<IList<LibraryPreviewResult>>();
+            void Previewhandler(object sender, IList<LibraryPreviewResult> args)
+            {
+                library.OnSearchPreviewComplete -= Previewhandler;
+                previewsFromHandlerTcs.SetResult(args);
+            }
+
+            library.OnSearchPreviewComplete += Previewhandler;
+
+            return previewsFromHandlerTcs;
+        }
+
+        /// <summary>
+        /// The name to be used when creating the js modules
+        /// </summary>
+        public override string Name => "ReactPSPDFKitLibrary";
+    }
+}

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PDFViewPage.xaml.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PDFViewPage.xaml.cs
@@ -10,14 +10,12 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using PSPDFKit.Document;
 using PSPDFKit.UI;
 using Windows.Storage;
 using Windows.UI.Popups;
 using Windows.UI.Xaml.Controls;
 using PSPDFKit.Pdf.Annotation;
 using ReactNative.UIManager;
-using ReactNative.UIManager.Events;
 using ReactNativePSPDFKit.Events;
 
 namespace ReactNativePSPDFKit

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitModule.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitModule.cs
@@ -59,11 +59,11 @@ namespace ReactNativePSPDFKit
             {
                 try
                 {
-                    var file = await StorageFile.GetFileFromApplicationUriAsync(new Uri(assetPath));
+                    var file = await StorageFile.GetFileFromPathAsync(assetPath);
 
                     await LoadFileAsync(file);
                 }
-                catch (Exception)
+                catch (Exception e)
                 {
                     var dialog = new MessageDialog("Unable to open the file specified.");
                     await dialog.ShowAsync();

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitPackage.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitPackage.cs
@@ -36,6 +36,7 @@ namespace ReactNativePSPDFKit
             return new List<INativeModule>
             {
                 new PSPDFKitModule(reactContext, _pspdfkitViewManger.PdfViewPage),
+                new LibraryModule(reactContext, _pspdfkitViewManger.PdfViewPage.Pdfview.License)
             };
         }
 

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/ReactNativePSPDFKit.csproj
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/ReactNativePSPDFKit.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Events\PdfViewDataReturnedEvent.cs" />
     <Compile Include="Events\PdfViewDocumentSaveFailedEvent.cs" />
     <Compile Include="JsonUtils.cs" />
+    <Compile Include="LibraryModule.cs" />
     <Compile Include="PSPDFKitModule.cs" />
     <Compile Include="PDFViewPage.xaml.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -136,7 +137,7 @@
     <SDKReference Include="Microsoft.VCLibs, Version=14.0">
       <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
     </SDKReference>
-    <SDKReference Include="PSPDFKitSDK, Version=1.6.0">
+    <SDKReference Include="PSPDFKitSDK, Version=1.6.1">
       <Name>PSPDFKit for UWP</Name>
     </SDKReference>
   </ItemGroup>

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/ReactNativePSPDFKit.csproj
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/ReactNativePSPDFKit.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Events\PdfViewDocumentSavedEvent.cs" />
     <Compile Include="Events\PdfViewDataReturnedEvent.cs" />
     <Compile Include="Events\PdfViewDocumentSaveFailedEvent.cs" />
+    <Compile Include="JsonUtils.cs" />
     <Compile Include="PSPDFKitModule.cs" />
     <Compile Include="PDFViewPage.xaml.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/ReactNativePSPDFKit.csproj
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/ReactNativePSPDFKit.csproj
@@ -141,6 +141,10 @@
     </SDKReference>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\react-native-fs\windows\RNFS\RNFS.csproj">
+      <Project>{746610d0-8693-11e7-a20d-bf83f7366778}</Project>
+      <Name>RNFS</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\..\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj">
       <Project>{c7673ad5-e3aa-468c-a5fd-fa38154e205c}</Project>
       <Name>ReactNative</Name>


### PR DESCRIPTION
The PR will add a new native module for the windows react native PSPDFKit layer.

`LibraryModule` exposes support for FTS in react native windows. You can open multiple libraries from either the picker or local folders in which the application has access to (use RNFS https://github.com/itinance/react-native-fs)

Configuration of the search is passed in via a json object which is converted internally and pass up to PSPDFKit windows. The results are passed back in a promise, the results comprises of a json objet with information dependent on the configuration. Much like the native library. 