### PR TITLE
Add support for programmatically removing annotations on iOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,6 +193,27 @@ class PSPDFKitView extends React.Component {
   };
 
   /**
+   * Removes an existing annotation from the current document.
+   *
+   * @param annotation InstantJson of the annotation to remove.
+   */
+  removeAnnotation = function(annotationName) {
+    if (Platform.OS === "android") {
+      // TODO: Uncomment once the Android implementaion is ready.
+      // UIManager.dispatchViewManagerCommand(
+      //   findNodeHandle(this.refs.pdfView),
+      //   UIManager.RCTPSPDFKitView.Commands.removeAnnotation,
+      //   [annotation]
+      // );
+    } else if (Platform.OS === "ios") {
+      NativeModules.PSPDFKitViewManager.removeAnnotation(
+        annotation,
+        findNodeHandle(this.refs.pdfView)
+      );
+    }
+  };
+
+  /**
    * Gets all unsaved changes to annotations.
    *
    * Returns a promise resolving to document instant json (https://pspdfkit.com/guides/android/current/importing-exporting/instant-json/#instant-document-json-api-a56628).

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ class PSPDFKitView extends React.Component {
         []
       );
     } else if (Platform.OS === "ios") {
-      NativeModules.PSPDFKitViewManager.enterAnnotationCreationMode(
+      return NativeModules.PSPDFKitViewManager.enterAnnotationCreationMode(
         findNodeHandle(this.refs.pdfView)
       );
     }
@@ -114,7 +114,7 @@ class PSPDFKitView extends React.Component {
         []
       );
     } else if (Platform.OS === "ios") {
-      NativeModules.PSPDFKitViewManager.exitCurrentlyActiveMode(
+      return NativeModules.PSPDFKitViewManager.exitCurrentlyActiveMode(
         findNodeHandle(this.refs.pdfView)
       );
     }
@@ -131,7 +131,7 @@ class PSPDFKitView extends React.Component {
         []
       );
     } else if (Platform.OS === "ios") {
-      NativeModules.PSPDFKitViewManager.saveCurrentDocument(
+      return NativeModules.PSPDFKitViewManager.saveCurrentDocument(
         findNodeHandle(this.refs.pdfView)
       );
     }

--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@ class PSPDFKitView extends React.Component {
         [annotation]
       );
     } else if (Platform.OS === "ios") {
-      NativeModules.PSPDFKitViewManager.addAnnotation(
+      return NativeModules.PSPDFKitViewManager.addAnnotation(
         annotation,
         findNodeHandle(this.refs.pdfView)
       );
@@ -197,7 +197,7 @@ class PSPDFKitView extends React.Component {
    *
    * @param annotation InstantJson of the annotation to remove.
    */
-  removeAnnotation = function(annotationName) {
+  removeAnnotation = function(annotation) {
     if (Platform.OS === "android") {
       // TODO: Uncomment once the Android implementaion is ready.
       // UIManager.dispatchViewManagerCommand(
@@ -206,7 +206,7 @@ class PSPDFKitView extends React.Component {
       //   [annotation]
       // );
     } else if (Platform.OS === "ios") {
-      NativeModules.PSPDFKitViewManager.removeAnnotation(
+      return NativeModules.PSPDFKitViewManager.removeAnnotation(
         annotation,
         findNodeHandle(this.refs.pdfView)
       );
@@ -255,7 +255,7 @@ class PSPDFKitView extends React.Component {
         [annotations]
       );
     } else if (Platform.OS === "ios") {
-      NativeModules.PSPDFKitViewManager.addAnnotations(
+      return NativeModules.PSPDFKitViewManager.addAnnotations(
         annotations,
         findNodeHandle(this.refs.pdfView)
       );

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.h
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.h
@@ -29,11 +29,11 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onStateChanged;
 
 /// Annotation Toolbar
-- (void)enterAnnotationCreationMode;
-- (void)exitCurrentlyActiveMode;
+- (BOOL)enterAnnotationCreationMode;
+- (BOOL)exitCurrentlyActiveMode;
 
 /// Document
-- (void)saveCurrentDocument;
+- (BOOL)saveCurrentDocument;
 
 /// Anotations
 - (NSDictionary<NSString *, NSArray<NSDictionary *> *> *)getAnnotations:(PSPDFPageIndex)pageIndex type:(PSPDFAnnotationType)type;

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.h
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.h
@@ -37,7 +37,8 @@
 
 /// Anotations
 - (NSDictionary<NSString *, NSArray<NSDictionary *> *> *)getAnnotations:(PSPDFPageIndex)pageIndex type:(PSPDFAnnotationType)type;
-- (void)addAnnotation:(NSString *)jsonAnnotation;
+- (void)addAnnotation:(id)jsonAnnotation;
+- (void)removeAnnotation:(id)jsonAnnotation;
 - (NSDictionary<NSString *, NSArray<NSDictionary *> *> *)getAllUnsavedAnnotations;
 - (void)addAnnotations:(NSString *)jsonAnnotations;
 

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.h
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.h
@@ -37,10 +37,10 @@
 
 /// Anotations
 - (NSDictionary<NSString *, NSArray<NSDictionary *> *> *)getAnnotations:(PSPDFPageIndex)pageIndex type:(PSPDFAnnotationType)type;
-- (void)addAnnotation:(id)jsonAnnotation;
-- (void)removeAnnotation:(id)jsonAnnotation;
+- (BOOL)addAnnotation:(id)jsonAnnotation;
+- (BOOL)removeAnnotation:(id)jsonAnnotation;
 - (NSDictionary<NSString *, NSArray<NSDictionary *> *> *)getAllUnsavedAnnotations;
-- (void)addAnnotations:(NSString *)jsonAnnotations;
+- (BOOL)addAnnotations:(NSString *)jsonAnnotations;
 
 /// Forms
 - (NSDictionary<NSString *, NSString *> *)getFormFieldValue:(NSString *)fullyQualifiedName;

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -178,7 +178,7 @@
   return @{@"annotations" : annotationsJSON};
 }
 
-- (void)addAnnotation:(id)jsonAnnotation {
+- (BOOL)addAnnotation:(id)jsonAnnotation {
   NSData *data;
   if ([jsonAnnotation isKindOfClass:NSString.class]) {
     data = [jsonAnnotation dataUsingEncoding:NSUTF8StringEncoding];
@@ -186,7 +186,7 @@
     data = [NSJSONSerialization dataWithJSONObject:jsonAnnotation options:0 error:nil];
   } else {
     NSLog(@"Invalid JSON Annotation.");
-    return;
+    return NO;
   }
   
   PSPDFDocument *document = self.pdfController.document;
@@ -201,9 +201,11 @@
   if (!success) {
     NSLog(@"Failed to add annotation.");
   }
+
+  return success;
 }
 
-- (void)removeAnnotation:(id)jsonAnnotation {
+- (BOOL)removeAnnotation:(id)jsonAnnotation {
   NSData *data;
   if ([jsonAnnotation isKindOfClass:NSString.class]) {
     data = [jsonAnnotation dataUsingEncoding:NSUTF8StringEncoding];
@@ -211,7 +213,7 @@
     data = [NSJSONSerialization dataWithJSONObject:jsonAnnotation options:0 error:nil];
   } else {
     NSLog(@"Invalid JSON Annotation.");
-    return;
+    return NO;
   }
 
   PSPDFDocument *document = self.pdfController.document;
@@ -232,6 +234,7 @@
   if (!success) {
     NSLog(@"Failed to remove annotation.");
   }
+  return success;
 }
 
 - (NSDictionary<NSString *, NSArray<NSDictionary *> *> *)getAllUnsavedAnnotations {
@@ -241,7 +244,7 @@
   return annotationsJSON;
 }
 
-- (void)addAnnotations:(id)jsonAnnotations {
+- (BOOL)addAnnotations:(id)jsonAnnotations {
   NSData *data;
   if ([jsonAnnotations isKindOfClass:NSString.class]) {
     data = [jsonAnnotations dataUsingEncoding:NSUTF8StringEncoding];
@@ -249,7 +252,7 @@
     data = [NSJSONSerialization dataWithJSONObject:jsonAnnotations options:0 error:nil];;
   } else {
     NSLog(@"Invalid JSON Annotations.");
-    return;
+    return NO;
   }
   
   PSPDFDataContainerProvider *dataContainerProvider = [[PSPDFDataContainerProvider alloc] initWithData:data];
@@ -259,6 +262,8 @@
   if (!success) {
     NSLog(@"Failed to add annotations.");
   }
+
+  return success;
 }
 
 #pragma mark - Forms

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -105,18 +105,18 @@
   return nil;
 }
 
-- (void)enterAnnotationCreationMode {
+- (BOOL)enterAnnotationCreationMode {
   [self.pdfController setViewMode:PSPDFViewModeDocument animated:YES];
   [self.pdfController.annotationToolbarController updateHostView:nil container:nil viewController:self.pdfController];
-  [self.pdfController.annotationToolbarController showToolbarAnimated:YES];
+  return [self.pdfController.annotationToolbarController showToolbarAnimated:YES];
 }
 
-- (void)exitCurrentlyActiveMode {
-  [self.pdfController.annotationToolbarController hideToolbarAnimated:YES];
+- (BOOL)exitCurrentlyActiveMode {
+  return [self.pdfController.annotationToolbarController hideToolbarAnimated:YES];
 }
 
-- (void)saveCurrentDocument {
-  [self.pdfController.document saveWithOptions:nil error:NULL];
+- (BOOL)saveCurrentDocument {
+  return [self.pdfController.document saveWithOptions:nil error:NULL];
 }
 
 #pragma mark - PSPDFDocumentDelegate
@@ -249,7 +249,7 @@
   if ([jsonAnnotations isKindOfClass:NSString.class]) {
     data = [jsonAnnotations dataUsingEncoding:NSUTF8StringEncoding];
   } else if ([jsonAnnotations isKindOfClass:NSDictionary.class])  {
-    data = [NSJSONSerialization dataWithJSONObject:jsonAnnotations options:0 error:nil];;
+    data = [NSJSONSerialization dataWithJSONObject:jsonAnnotations options:0 error:nil];
   } else {
     NSLog(@"Invalid JSON Annotations.");
     return NO;

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -203,6 +203,37 @@
   }
 }
 
+- (void)removeAnnotation:(id)jsonAnnotation {
+  NSData *data;
+  if ([jsonAnnotation isKindOfClass:NSString.class]) {
+    data = [jsonAnnotation dataUsingEncoding:NSUTF8StringEncoding];
+  } else if ([jsonAnnotation isKindOfClass:NSDictionary.class])  {
+    data = [NSJSONSerialization dataWithJSONObject:jsonAnnotation options:0 error:nil];
+  } else {
+    NSLog(@"Invalid JSON Annotation.");
+    return;
+  }
+
+  PSPDFDocument *document = self.pdfController.document;
+  PSPDFDocumentProvider *documentProvider = document.documentProviders.firstObject;
+
+  BOOL success = NO;
+  if (data) {
+    PSPDFAnnotation *annotationToRemove = [PSPDFAnnotation annotationFromInstantJSON:data documentProvider:documentProvider error:NULL];
+    for (PSPDFAnnotation *annotation in [document annotationsForPageAtIndex:annotationToRemove.pageIndex type:annotationToRemove.type]) {
+      // Remove the annotation if the name matches.
+      if ([annotation.name isEqualToString:annotationToRemove.name]) {
+        success = [document removeAnnotations:@[annotation] options:nil];
+        break;
+      }
+    }
+  }
+
+  if (!success) {
+    NSLog(@"Failed to remove annotation.");
+  }
+}
+
 - (NSDictionary<NSString *, NSArray<NSDictionary *> *> *)getAllUnsavedAnnotations {
   PSPDFDocumentProvider *documentProvider = self.pdfController.document.documentProviders.firstObject;
   NSData *data = [self.pdfController.document generateInstantJSONFromDocumentProvider:documentProvider error:NULL];

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -76,24 +76,39 @@ RCT_EXPORT_VIEW_PROPERTY(onAnnotationsChanged, RCTBubblingEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(onStateChanged, RCTBubblingEventBlock)
 
-RCT_EXPORT_METHOD(enterAnnotationCreationMode:(nonnull NSNumber *)reactTag) {
+RCT_EXPORT_METHOD(enterAnnotationCreationMode:(nonnull NSNumber *)reactTag resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   dispatch_async(dispatch_get_main_queue(), ^{
     RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];
-    [component enterAnnotationCreationMode];
+    BOOL success = [component enterAnnotationCreationMode];
+    if (success) {
+      resolve(@(success));
+    } else {
+      reject(@"error", @"Failed to enter annotation creation mode.", nil);
+    }
   });
 }
 
-RCT_EXPORT_METHOD(exitCurrentlyActiveMode:(nonnull NSNumber *)reactTag) {
+RCT_EXPORT_METHOD(exitCurrentlyActiveMode:(nonnull NSNumber *)reactTag resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   dispatch_async(dispatch_get_main_queue(), ^{
     RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];
-    [component exitCurrentlyActiveMode];
+    BOOL success = [component exitCurrentlyActiveMode];
+    if (success) {
+      resolve(@(success));
+    } else {
+      reject(@"error", @"Failed to exit annotation creation mode.", nil);
+    }
   });
 }
 
-RCT_EXPORT_METHOD(saveCurrentDocument:(nonnull NSNumber *)reactTag) {
+RCT_EXPORT_METHOD(saveCurrentDocument:(nonnull NSNumber *)reactTag resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   dispatch_async(dispatch_get_main_queue(), ^{
     RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];
-    [component saveCurrentDocument];
+    BOOL success = [component saveCurrentDocument];
+    if (success) {
+      resolve(@(success));
+    } else {
+      reject(@"error", @"Failed to save document.", nil);
+    }
   });
 }
 

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -95,7 +95,7 @@ RCT_EXPORT_METHOD(exitCurrentlyActiveMode:(nonnull NSNumber *)reactTag resolver:
     if (success) {
       resolve(@(success));
     } else {
-      reject(@"error", @"Failed to exit annotation creation mode.", nil);
+      reject(@"error", @"Failed to exit currently active mode.", nil);
     }
   });
 }

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -109,17 +109,27 @@ RCT_REMAP_METHOD(getAnnotations, getAnnotations:(nonnull NSNumber *)pageIndex ty
   });
 }
 
-RCT_EXPORT_METHOD(addAnnotation:(id)jsonAnnotation reactTag:(nonnull NSNumber *)reactTag) {
+RCT_EXPORT_METHOD(addAnnotation:(id)jsonAnnotation reactTag:(nonnull NSNumber *)reactTag resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   dispatch_async(dispatch_get_main_queue(), ^{
     RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];
-    [component addAnnotation:jsonAnnotation];
+    BOOL success = [component addAnnotation:jsonAnnotation];
+    if (success) {
+      resolve(@(success));
+    } else {
+      reject(@"error", @"Failed to add annotation.", nil);
+    }
   });
 }
 
-RCT_EXPORT_METHOD(removeAnnotation:(id)jsonAnnotation reactTag:(nonnull NSNumber *)reactTag) {
+RCT_EXPORT_METHOD(removeAnnotation:(id)jsonAnnotation reactTag:(nonnull NSNumber *)reactTag resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   dispatch_async(dispatch_get_main_queue(), ^{
     RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];
-    [component removeAnnotation:jsonAnnotation];
+    BOOL success = [component removeAnnotation:jsonAnnotation];
+    if (success) {
+      resolve(@(success));
+    } else {
+      reject(@"error", @"Failed to remove annotation.", nil);
+    }
   });
 }
 
@@ -135,10 +145,15 @@ RCT_EXPORT_METHOD(getAllUnsavedAnnotations:(nonnull NSNumber *)reactTag resolver
   });
 }
 
-RCT_EXPORT_METHOD(addAnnotations:(id)jsonAnnotations reactTag:(nonnull NSNumber *)reactTag) {
+RCT_EXPORT_METHOD(addAnnotations:(id)jsonAnnotations reactTag:(nonnull NSNumber *)reactTag resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   dispatch_async(dispatch_get_main_queue(), ^{
     RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];
-    [component addAnnotations:jsonAnnotations];
+    BOOL success = [component addAnnotations:jsonAnnotations];
+    if (success) {
+      resolve(@(success));
+    } else {
+      reject(@"error", @"Failed to add annotations.", nil);
+    }
   });
 }
 

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -116,6 +116,13 @@ RCT_EXPORT_METHOD(addAnnotation:(id)jsonAnnotation reactTag:(nonnull NSNumber *)
   });
 }
 
+RCT_EXPORT_METHOD(removeAnnotation:(id)jsonAnnotation reactTag:(nonnull NSNumber *)reactTag) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];
+    [component removeAnnotation:jsonAnnotation];
+  });
+}
+
 RCT_EXPORT_METHOD(getAllUnsavedAnnotations:(nonnull NSNumber *)reactTag resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   dispatch_async(dispatch_get_main_queue(), ^{
     RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];

--- a/samples/Catalog/Catalog.ios.js
+++ b/samples/Catalog/Catalog.ios.js
@@ -593,6 +593,7 @@ class ProgrammaticAnnotations extends Component {
                   },
                   opacity: 1,
                   pageIndex: 0,
+                  name: "A167811E-6D10-4546-A147-B7AD775FE8AC",
                   strokeColor: "#AA47BE",
                   type: "pspdfkit/ink",
                   v: 1
@@ -600,6 +601,46 @@ class ProgrammaticAnnotations extends Component {
                 this.refs.pdfView.addAnnotation(annotationJSON);
               }}
               title="addAnnotation"
+            />
+          </View>
+          <View>
+            <Button
+              onPress={() => {
+                // Programmatically remove an existing ink annotation.
+                const annotationJSON = {
+                  bbox: [
+                    89.586334228515625,
+                    98.5791015625,
+                    143.12948608398438,
+                    207.1583251953125
+                  ],
+                  isDrawnNaturally: false,
+                  lineWidth: 5,
+                  lines: {
+                    intensities: [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5]],
+                    points: [
+                      [
+                        [92.086334228515625, 101.07916259765625],
+                        [92.086334228515625, 202.15826416015625],
+                        [138.12950134277344, 303.2374267578125]
+                      ],
+                      [
+                        [184.17266845703125, 101.07916259765625],
+                        [184.17266845703125, 202.15826416015625],
+                        [230.2158203125, 303.2374267578125]
+                      ]
+                    ]
+                  },
+                  opacity: 1,
+                  pageIndex: 0,
+                  name: "A167811E-6D10-4546-A147-B7AD775FE8AC",
+                  strokeColor: "#AA47BE",
+                  type: "pspdfkit/ink",
+                  v: 1
+                };
+                this.refs.pdfView.removeAnnotation(annotationJSON);
+              }}
+              title="removeAnnotation"
             />
           </View>
           <View>
@@ -635,6 +676,7 @@ class ProgrammaticAnnotations extends Component {
                       },
                       isDrawnNaturally: false,
                       strokeColor: "#AA47BE",
+                      name: "A167811E-6D10-4546-A147-B7AD775FE8AC",
                       updatedAt: "2018-07-30T15:34:48Z",
                       pageIndex: 0,
                       opacity: 1,

--- a/samples/Catalog/Catalog.ios.js
+++ b/samples/Catalog/Catalog.ios.js
@@ -605,40 +605,14 @@ class ProgrammaticAnnotations extends Component {
           </View>
           <View>
             <Button
-              onPress={() => {
+              onPress={async () => {
                 // Programmatically remove an existing ink annotation.
-                const annotationJSON = {
-                  bbox: [
-                    89.586334228515625,
-                    98.5791015625,
-                    143.12948608398438,
-                    207.1583251953125
-                  ],
-                  isDrawnNaturally: false,
-                  lineWidth: 5,
-                  lines: {
-                    intensities: [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5]],
-                    points: [
-                      [
-                        [92.086334228515625, 101.07916259765625],
-                        [92.086334228515625, 202.15826416015625],
-                        [138.12950134277344, 303.2374267578125]
-                      ],
-                      [
-                        [184.17266845703125, 101.07916259765625],
-                        [184.17266845703125, 202.15826416015625],
-                        [230.2158203125, 303.2374267578125]
-                      ]
-                    ]
-                  },
-                  opacity: 1,
-                  pageIndex: 0,
-                  name: "A167811E-6D10-4546-A147-B7AD775FE8AC",
-                  strokeColor: "#AA47BE",
-                  type: "pspdfkit/ink",
-                  v: 1
-                };
-                this.refs.pdfView.removeAnnotation(annotationJSON);
+                const inkAnnotations = await this.refs.pdfView.getAnnotations(
+                  this.state.currentPageIndex,
+                  "pspdfkit/ink"
+                );
+                const firstInkAnnotation = inkAnnotations["annotations"][0];
+                this.refs.pdfView.removeAnnotation(firstInkAnnotation);
               }}
               title="removeAnnotation"
             />


### PR DESCRIPTION
# Details

iOS implementation of #142

![recording](https://user-images.githubusercontent.com/7443038/48272027-ac392700-e40b-11e8-97e7-046891835b9d.gif)

# Acceptance Criteria

- [x] Add `removeAnnotation` method to `RCTPSPDFKitView` on iOS.
- [x] Update the 'Programmatic Annotations' Catalog example to show how to use the newly added API.
- [x] Make sure that the current implementation does not impact Android.
- [x] Make sure that the current implementation does not impact Windows.