### PR TITLE
Add presentInstant method to open an instant document

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -73,8 +73,14 @@ dependencies {
         compile("com.pspdfkit:pspdfkit-demo:${PSPDFKIT_VERSION}") {
             exclude group: 'com.google.auto.value', module: 'auto-value'
         }
+        compile("com.pspdfkit:pspdfkit-instant-demo:${PSPDFKIT_VERSION}") {
+            exclude group: 'com.google.auto.value', module: 'auto-value'
+        }
     } else {
         compile("com.pspdfkit:pspdfkit:${PSPDFKIT_VERSION}") {
+            exclude group: 'com.google.auto.value', module: 'auto-value'
+        }
+        compile("com.pspdfkit:pspdfkit-instant:${PSPDFKIT_VERSION}") {
             exclude group: 'com.google.auto.value', module: 'auto-value'
         }
     }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -21,8 +21,13 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
     <application>
-    <activity
-        android:name="com.pspdfkit.ui.PdfActivity"
-        android:windowSoftInputMode="adjustNothing" />
+        <activity
+            android:name="com.pspdfkit.ui.PdfActivity"
+            android:windowSoftInputMode="adjustNothing" />
+
+        <activity
+            android:name="com.pspdfkit.instant.ui.InstantPdfActivity"
+            android:windowSoftInputMode="adjustNothing" />
+
     </application>
 </manifest>

--- a/android/src/main/java/com/pspdfkit/react/PSPDFKitModule.java
+++ b/android/src/main/java/com/pspdfkit/react/PSPDFKitModule.java
@@ -34,6 +34,7 @@ import com.pspdfkit.PSPDFKit;
 import com.pspdfkit.document.PdfDocument;
 import com.pspdfkit.document.image.CameraImagePickerFragment;
 import com.pspdfkit.document.image.GalleryImagePickerFragment;
+import com.pspdfkit.instant.ui.InstantPdfActivity;
 import com.pspdfkit.listeners.SimpleDocumentListener;
 import com.pspdfkit.ui.PdfActivity;
 import com.pspdfkit.ui.PdfFragment;
@@ -112,6 +113,18 @@ public class PSPDFKitModule extends ReactContextBaseJavaModule implements Applic
             }
 
             PdfActivity.showImage(getCurrentActivity(), Uri.parse(imageDocument), configurationAdapter.build());
+        }
+    }
+
+    @ReactMethod
+    public void presentInstant(@NonNull String serverUrl, @NonNull String jwt, @NonNull ReadableMap configuration) {
+        if (getCurrentActivity() != null) {
+            if (resumedActivity == null) {
+                // We register an activity lifecycle callback so we can get notified of the current activity.
+                getCurrentActivity().getApplication().registerActivityLifecycleCallbacks(this);
+            }
+            ConfigurationAdapter configurationAdapter = new ConfigurationAdapter(getCurrentActivity(), configuration);
+            InstantPdfActivity.showInstantDocument(getCurrentActivity(), serverUrl, jwt, configurationAdapter.build());
         }
     }
 

--- a/samples/Catalog/android/app/build.gradle
+++ b/samples/Catalog/android/app/build.gradle
@@ -152,6 +152,16 @@ dependencies {
     androidTestCompile('com.android.support.test:rules:1.0.2') {
         exclude group: 'com.android.support'
     }
+
+    // For the instant example
+    compile (project(':react-native-camera')) {
+        exclude group: "com.google.android.gms"
+        compile 'com.android.support:exifinterface:27.+'
+        compile ('com.google.android.gms:play-services-vision:12.0.1') {
+            force = true
+        }
+    }
+
     // Optional -- Hamcrest library
     androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
     // Optional -- UI testing with Espresso

--- a/samples/Catalog/android/app/src/main/AndroidManifest.xml
+++ b/samples/Catalog/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,8 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.VIBRATE"/>
 
     <application
         android:name=".MainApplication"

--- a/samples/Catalog/android/app/src/main/java/com/pspdfkit/react/catalog/MainApplication.java
+++ b/samples/Catalog/android/app/src/main/java/com/pspdfkit/react/catalog/MainApplication.java
@@ -17,6 +17,7 @@ import android.app.Application;
 
 import com.facebook.react.ReactApplication;
 import com.rnfs.RNFSPackage;
+import org.reactnative.camera.RNCameraPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
@@ -39,6 +40,7 @@ public class MainApplication extends Application implements ReactApplication {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
           new RNFSPackage(),
+          new RNCameraPackage(),
           new PSPDFKitPackage()
       );
     }

--- a/samples/Catalog/android/gradle.properties
+++ b/samples/Catalog/android/gradle.properties
@@ -18,4 +18,5 @@
 # org.gradle.parallel=true
 
 android.useDeprecatedNdk=true
+org.gradle.configureondemand=false
 org.gradle.jvmargs=-Xmx2G -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/samples/Catalog/android/settings.gradle
+++ b/samples/Catalog/android/settings.gradle
@@ -1,4 +1,7 @@
 rootProject.name = 'Catalog'
+include ':react-native-camera'
+project(':react-native-camera').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-camera/android')
+
 include ':react-native-fs'
 project(':react-native-fs').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-fs/android')
 

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -8,8 +8,10 @@
   "dependencies": {
     "react": "16.3.1",
     "react-native": "0.55.4",
+    "react-native-camera": "^1.3.1",
     "react-native-fs": "2.10.14",
     "react-native-pspdfkit": "file:../../",
+    "react-native-qrcode-scanner": "^1.1.0",
     "react-native-windows": "0.53.0",
     "react-navigation": "^1.0.3"
   },

--- a/samples/Catalog/yarn.lock
+++ b/samples/Catalog/yarn.lock
@@ -5320,6 +5320,14 @@ prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -5382,6 +5390,14 @@ react-lifecycles-compat@^3.0.2:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-native-camera@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-camera/-/react-native-camera-1.3.1.tgz#d7c1a207bfc33b11c130762d6b494b4169562463"
+  integrity sha512-IFhU+7ax60eXnqqoTI0r6l/2AoZcYduBJ3tLKdDPue/1w6Fnfx5f2BEIU3hTNzjGX3v29vz+xZNKo0pwcrJmOA==
+  dependencies:
+    lodash "^4.17.10"
+    prop-types "^15.6.2"
+
 react-native-dismiss-keyboard@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/react-native-dismiss-keyboard/-/react-native-dismiss-keyboard-1.0.0.tgz#32886242b3f2317e121f3aeb9b0a585e2b879b49"
@@ -5409,8 +5425,21 @@ react-native-fs@2.10.14:
     base-64 "^0.1.0"
     utf8 "^2.1.1"
 
+react-native-permissions@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-1.1.1.tgz#4876004681ff8556454613d85249b01baff9b35b"
+  integrity sha512-t0Ujm177bagjUOSzhpmkSz+LqFW04HnY9TeZFavDCmV521fQvFz82aD+POXqWsAdsJVOK3umJYBNNqCjC3g0hQ==
+
 "react-native-pspdfkit@file:../..":
-  version "1.20.0"
+  version "1.22.0"
+
+react-native-qrcode-scanner@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-qrcode-scanner/-/react-native-qrcode-scanner-1.1.0.tgz#6a2e88110e0c1def94690a4d52fc383634ed6e4c"
+  integrity sha512-Z0lm9vEVMnVrzlZUrlo29OvSmYSBmDdzRi4mjLsWbQ6uzxZE9aNL1wjxnO7KvBL9Q3HKji6mybj1+fdpUMbDxg==
+  dependencies:
+    prop-types "^15.5.10"
+    react-native-permissions "^1.1.1"
 
 react-native-safe-area-view@^0.7.0:
   version "0.7.0"


### PR DESCRIPTION
- Adds `presentInstant` to the `PSPDFKitModule` which allows you to open instant documents.
- Adds `Instant Example` to Android Catalog which scans the QR Codes provided on https://pspdfkit.com/instant/demo/