### PR TITLE
Add support for setting a custom menu grouping on the PSPDFKitView

### DIFF
--- a/android/src/main/java/com/pspdfkit/react/ReactPdfViewManager.java
+++ b/android/src/main/java/com/pspdfkit/react/ReactPdfViewManager.java
@@ -19,6 +19,7 @@ import com.pspdfkit.react.events.PdfViewDataReturnedEvent;
 import com.pspdfkit.react.events.PdfViewDocumentSaveFailedEvent;
 import com.pspdfkit.react.events.PdfViewDocumentSavedEvent;
 import com.pspdfkit.react.events.PdfViewStateChangedEvent;
+import com.pspdfkit.react.menu.ReactGroupingRule;
 import com.pspdfkit.views.PdfView;
 
 import org.json.JSONObject;
@@ -135,6 +136,12 @@ public class ReactPdfViewManager extends ViewGroupManager<PdfView> {
     @ReactProp(name = "annotationAuthorName")
     public void setAnnotationAuthorName(PdfView view, String annotationAuthorName) {
         PSPDFKitPreferences.get(view.getContext()).setAnnotationCreator(annotationAuthorName);
+    }
+
+    @ReactProp(name = "menuItemGrouping")
+    public void setMenuItemGrouping(PdfView view, @NonNull ReadableArray menuItemGrouping) {
+        ReactGroupingRule groupingRule = new ReactGroupingRule(view.getContext(), menuItemGrouping);
+        view.setMenuItemGroupingRule(groupingRule);
     }
 
     @Nullable

--- a/android/src/main/java/com/pspdfkit/react/menu/ReactGroupingRule.java
+++ b/android/src/main/java/com/pspdfkit/react/menu/ReactGroupingRule.java
@@ -1,0 +1,117 @@
+package com.pspdfkit.react.menu;
+
+import android.content.Context;
+import android.support.annotation.IdRes;
+import android.support.annotation.IntRange;
+import android.support.annotation.NonNull;
+
+import com.facebook.react.bridge.Dynamic;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableType;
+import com.pspdfkit.react.R;
+import com.pspdfkit.ui.toolbar.ContextualToolbar;
+import com.pspdfkit.ui.toolbar.grouping.presets.MenuItem;
+import com.pspdfkit.ui.toolbar.grouping.presets.PresetMenuItemGroupingRule;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ReactGroupingRule extends PresetMenuItemGroupingRule {
+
+    private static final int INVALID_ID = -1;
+
+    private final List<MenuItem> items = new ArrayList<>();
+
+    public ReactGroupingRule(@NonNull Context context, @NonNull ReadableArray menuItems) {
+        super(context);
+        for (int i = 0; i < menuItems.size(); i++) {
+            Dynamic menuItem = menuItems.getDynamic(i);
+            if (menuItem.getType() == ReadableType.Map) {
+                ReadableMap groupItem = menuItem.asMap();
+                int key = getIdFromName(groupItem.getString("key"));
+                if (key == INVALID_ID) {
+                    continue;
+                }
+                ReadableArray subitems = groupItem.getArray("items");
+                int[] itemIds = new int[subitems.size()];
+                for (int j = 0; j < itemIds.length; j++) {
+                    int id = getIdFromName(subitems.getString(j));
+                    if (id == INVALID_ID) {
+                        continue;
+                    }
+                    itemIds[j] = id;
+                }
+                items.add(new MenuItem(key, itemIds));
+            } else {
+                int id = getIdFromName(menuItem.asString());
+                if (id == INVALID_ID) {
+                    continue;
+                }
+                items.add(new MenuItem(id));
+            }
+        }
+    }
+
+    @IdRes
+    private int getIdFromName(@NonNull String name) {
+        switch (name) {
+            case "markup":
+                return R.id.pspdf__annotation_creation_toolbar_item_markup;
+            case "writing":
+                return R.id.pspdf__annotation_creation_toolbar_item_writing;
+            case "highlight":
+                return R.id.pspdf__annotation_creation_toolbar_item_highlight;
+            case "squiggly":
+                return R.id.pspdf__annotation_creation_toolbar_item_squiggly;
+            case "strikeout":
+                return R.id.pspdf__annotation_creation_toolbar_item_strikeout;
+            case "underline":
+                return R.id.pspdf__annotation_creation_toolbar_item_underline;
+            case "freetext":
+                return R.id.pspdf__annotation_creation_toolbar_item_freetext;
+            case "freetext_callout":
+                return R.id.pspdf__annotation_creation_toolbar_item_freetext_callout;
+            case "signature":
+                return R.id.pspdf__annotation_creation_toolbar_item_signature;
+            case "ink":
+                return R.id.pspdf__annotation_creation_toolbar_item_ink;
+            case "note":
+                return R.id.pspdf__annotation_creation_toolbar_item_note;
+            case "drawing":
+                return R.id.pspdf__annotation_creation_toolbar_item_drawing;
+            case "multimedia":
+                return R.id.pspdf__annotation_creation_toolbar_item_multimedia;
+            case "image":
+                return R.id.pspdf__annotation_creation_toolbar_item_image;
+            case "camera":
+                return R.id.pspdf__annotation_creation_toolbar_item_camera;
+            case "stamp":
+                return R.id.pspdf__annotation_creation_toolbar_item_stamp;
+            case "line":
+                return R.id.pspdf__annotation_creation_toolbar_item_line;
+            case "square":
+                return R.id.pspdf__annotation_creation_toolbar_item_square;
+            case "circle":
+                return R.id.pspdf__annotation_creation_toolbar_item_circle;
+            case "polygon":
+                return R.id.pspdf__annotation_creation_toolbar_item_polygon;
+            case "polyline":
+                return R.id.pspdf__annotation_creation_toolbar_item_polyline;
+            case "erase":
+                return R.id.pspdf__annotation_creation_toolbar_item_eraser;
+            case "redaction":
+                return R.id.pspdf__annotation_creation_toolbar_item_redaction;
+            case "picker":
+                return R.id.pspdf__annotation_creation_toolbar_item_picker;
+        }
+
+        return INVALID_ID;
+    }
+
+    @NonNull
+    @Override
+    public List<MenuItem> getGroupPreset(@IntRange(from = ContextualToolbar.MIN_TOOLBAR_CAPACITY) int capacity, int itemsCount) {
+        return items;
+    }
+}

--- a/android/src/main/java/com/pspdfkit/views/PdfView.java
+++ b/android/src/main/java/com/pspdfkit/views/PdfView.java
@@ -41,6 +41,7 @@ import com.pspdfkit.ui.forms.FormEditingBar;
 import com.pspdfkit.ui.inspector.PropertyInspectorCoordinatorLayout;
 import com.pspdfkit.ui.thumbnail.PdfThumbnailBarController;
 import com.pspdfkit.ui.toolbar.ToolbarCoordinatorLayout;
+import com.pspdfkit.ui.toolbar.grouping.MenuItemGroupingRule;
 import com.pspdfkit.ui.toolbar.popup.PdfTextSelectionPopupToolbar;
 
 import org.json.JSONArray;
@@ -201,6 +202,10 @@ public class PdfView extends FrameLayout {
 
     public void setDisableAutomaticSaving(boolean disableAutomaticSaving) {
         pdfViewDocumentListener.setDisableAutomaticSaving(disableAutomaticSaving);
+    }
+
+    public void setMenuItemGroupingRule(@NonNull MenuItemGroupingRule groupingRule) {
+        pdfViewModeController.setMenuItemGroupingRule(groupingRule);
     }
 
     private void setupFragment() {

--- a/android/src/main/java/com/pspdfkit/views/PdfViewModeController.java
+++ b/android/src/main/java/com/pspdfkit/views/PdfViewModeController.java
@@ -2,6 +2,7 @@ package com.pspdfkit.views;
 
 import android.support.annotation.NonNull;
 
+import com.pspdfkit.react.R;
 import com.pspdfkit.ui.forms.FormEditingBar;
 import com.pspdfkit.ui.inspector.PropertyInspectorCoordinatorLayout;
 import com.pspdfkit.ui.inspector.annotation.DefaultAnnotationCreationInspectorController;
@@ -17,6 +18,9 @@ import com.pspdfkit.ui.special_mode.manager.TextSelectionManager;
 import com.pspdfkit.ui.toolbar.AnnotationCreationToolbar;
 import com.pspdfkit.ui.toolbar.AnnotationEditingToolbar;
 import com.pspdfkit.ui.toolbar.ToolbarCoordinatorLayout;
+import com.pspdfkit.ui.toolbar.grouping.MenuItemGroupingRule;
+
+import javax.annotation.Nullable;
 
 /**
  * Keeps track of the currently active mode and handles updating the toolbar states.
@@ -54,6 +58,10 @@ class PdfViewModeController implements AnnotationManager.OnAnnotationCreationMod
         this.annotationCreationInspectorController = new DefaultAnnotationCreationInspectorController(parent.getContext(), inspectorCoordinatorLayout);
         this.annotationEditingInspectorController = new DefaultAnnotationEditingInspectorController(parent.getContext(), inspectorCoordinatorLayout);
         this.formEditingInspectorController = new FormEditingInspectorController(parent.getContext(), inspectorCoordinatorLayout);
+    }
+
+    public void setMenuItemGroupingRule(@Nullable MenuItemGroupingRule groupingRule) {
+        this.annotationCreationToolbar.setMenuItemGroupingRule(groupingRule);
     }
 
     @Override

--- a/index.js
+++ b/index.js
@@ -421,7 +421,11 @@ PSPDFKitView.propTypes = {
    *
    * @platform android
    */
-  fragmentTag: PropTypes.string
+  fragmentTag: PropTypes.string,
+  /**
+   * menuItemGrouping: Can be used to specfiy a custom grouping for the menu items in the annotation creation toolbar.
+   */
+  menuItemGrouping: PropTypes.array
 };
 
 if (Platform.OS === "ios" || Platform.OS === "android") {

--- a/ios/RCTPSPDFKit.xcodeproj/project.pbxproj
+++ b/ios/RCTPSPDFKit.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		6572780C1D86AE7300A5E1A8 /* RCTConvert+PSPDFConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 657278071D86AE7300A5E1A8 /* RCTConvert+PSPDFConfiguration.m */; };
 		657278111D86AEC600A5E1A8 /* RCTConvert+PSPDFDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 657278101D86AEC600A5E1A8 /* RCTConvert+PSPDFDocument.m */; };
 		84545BA4210A5CCF00FBB0A7 /* RCTConvert+PSPDFAnnotation.m in Sources */ = {isa = PBXBuildFile; fileRef = 84545BA2210A5CCF00FBB0A7 /* RCTConvert+PSPDFAnnotation.m */; };
+		B783BA3421C3F55300FD981A /* RCTConvert+PSPDFAnnotationToolbarConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = B783BA3321C3F55300FD981A /* RCTConvert+PSPDFAnnotationToolbarConfiguration.m */; };
 		F84F8B192032D54F00153D9E /* RCTPSPDFKitView.m in Sources */ = {isa = PBXBuildFile; fileRef = F84F8B182032D54F00153D9E /* RCTPSPDFKitView.m */; };
 		F8C1A2E5202DCC9700E98192 /* RCTPSPDFKitViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F8C1A2E4202DCC9700E98192 /* RCTPSPDFKitViewManager.m */; };
 /* End PBXBuildFile section */
@@ -37,6 +38,8 @@
 		657278101D86AEC600A5E1A8 /* RCTConvert+PSPDFDocument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RCTConvert+PSPDFDocument.m"; sourceTree = "<group>"; };
 		84545BA2210A5CCF00FBB0A7 /* RCTConvert+PSPDFAnnotation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RCTConvert+PSPDFAnnotation.m"; sourceTree = "<group>"; };
 		84545BA3210A5CCF00FBB0A7 /* RCTConvert+PSPDFAnnotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+PSPDFAnnotation.h"; sourceTree = "<group>"; };
+		B783BA3221C3F55300FD981A /* RCTConvert+PSPDFAnnotationToolbarConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+PSPDFAnnotationToolbarConfiguration.h"; sourceTree = "<group>"; };
+		B783BA3321C3F55300FD981A /* RCTConvert+PSPDFAnnotationToolbarConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "RCTConvert+PSPDFAnnotationToolbarConfiguration.m"; sourceTree = "<group>"; };
 		F84F8B182032D54F00153D9E /* RCTPSPDFKitView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTPSPDFKitView.m; sourceTree = "<group>"; };
 		F84F8B1A2032D55E00153D9E /* RCTPSPDFKitView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTPSPDFKitView.h; sourceTree = "<group>"; };
 		F8C1A2E4202DCC9700E98192 /* RCTPSPDFKitViewManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTPSPDFKitViewManager.m; sourceTree = "<group>"; };
@@ -77,6 +80,8 @@
 				657278071D86AE7300A5E1A8 /* RCTConvert+PSPDFConfiguration.m */,
 				6572780F1D86AEC600A5E1A8 /* RCTConvert+PSPDFDocument.h */,
 				657278101D86AEC600A5E1A8 /* RCTConvert+PSPDFDocument.m */,
+				B783BA3221C3F55300FD981A /* RCTConvert+PSPDFAnnotationToolbarConfiguration.h */,
+				B783BA3321C3F55300FD981A /* RCTConvert+PSPDFAnnotationToolbarConfiguration.m */,
 			);
 			path = Converters;
 			sourceTree = "<group>";
@@ -161,6 +166,7 @@
 				F8C1A2E5202DCC9700E98192 /* RCTPSPDFKitViewManager.m in Sources */,
 				84545BA4210A5CCF00FBB0A7 /* RCTConvert+PSPDFAnnotation.m in Sources */,
 				6540D1841D89D22E00B8F94F /* RCTPSPDFKitManager.m in Sources */,
+				B783BA3421C3F55300FD981A /* RCTConvert+PSPDFAnnotationToolbarConfiguration.m in Sources */,
 				F84F8B192032D54F00153D9E /* RCTPSPDFKitView.m in Sources */,
 				6572780C1D86AE7300A5E1A8 /* RCTConvert+PSPDFConfiguration.m in Sources */,
 			);

--- a/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFAnnotationToolbarConfiguration.h
+++ b/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFAnnotationToolbarConfiguration.h
@@ -1,0 +1,18 @@
+//
+//  Copyright © 2018 PSPDFKit GmbH. All rights reserved.
+//
+//  THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY INTERNATIONAL COPYRIGHT LAW
+//  AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT.
+//  UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
+//  This notice may not be removed from this file.
+//
+
+#import <React/RCTConvert.h>
+@import PSPDFKit;
+@import PSPDFKitUI;
+
+@interface RCTConvert (PSPDFAnnotationToolbarConfiguration)
+
++ (PSPDFAnnotationToolbarConfiguration *)PSPDFAnnotationToolbarConfiguration:(id)json;
+
+@end

--- a/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFAnnotationToolbarConfiguration.m
+++ b/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFAnnotationToolbarConfiguration.m
@@ -1,0 +1,85 @@
+//
+//  Copyright © 2018 PSPDFKit GmbH. All rights reserved.
+//
+//  THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY INTERNATIONAL COPYRIGHT LAW
+//  AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT.
+//  UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
+//  This notice may not be removed from this file.
+//
+
+#import "RCTConvert+PSPDFDocument.h"
+
+@implementation RCTConvert (PSPDFAnnotationToolbarConfiguration)
+
++ (PSPDFAnnotationToolbarConfiguration *)PSPDFAnnotationToolbarConfiguration:(id)json {
+  NSArray *itemsToParse = [RCTConvert NSArray:json];
+  NSMutableArray *parsedItems = [NSMutableArray arrayWithCapacity:itemsToParse.count];
+  for (int i = 0; i < itemsToParse.count; i++) {
+    id itemToParse = itemsToParse[i];
+    if ([itemToParse isKindOfClass:[NSDictionary class]]) {
+      NSDictionary *dict = itemToParse;
+      NSArray *subArray = dict[@"items"];
+      NSMutableArray *subItems = [NSMutableArray arrayWithCapacity:subArray.count];
+      for (int j = 0; j < subArray.count; j++) {
+        id subItem = subArray[j];
+        PSPDFAnnotationString annotationString = [RCTConvert PSPDFAnnotationStringFromName:subItem];
+        if (subItem) {
+          [subItems addObject:[PSPDFAnnotationGroupItem itemWithType:annotationString]];
+        }
+      }
+      [parsedItems addObject:[PSPDFAnnotationGroup groupWithItems:subItems]];
+    } else {
+      PSPDFAnnotationString annotationString = [RCTConvert PSPDFAnnotationStringFromName:itemToParse];
+      if (annotationString) {
+        [parsedItems addObject:[PSPDFAnnotationGroup groupWithItems:@[[PSPDFAnnotationGroupItem itemWithType:annotationString]]]];
+      }
+    }
+  }
+  return  [[PSPDFAnnotationToolbarConfiguration alloc] initWithAnnotationGroups:parsedItems];
+}
+
++ (PSPDFAnnotationString)PSPDFAnnotationStringFromName:(NSString *)name {
+  if ([name isEqualToString:@"link"]) {
+    return PSPDFAnnotationStringLink;
+  } else if ([name isEqualToString:@"highlight"]) {
+    return PSPDFAnnotationStringHighlight;
+  } else if ([name isEqualToString:@"strikeout"]) {
+    return PSPDFAnnotationMenuStrikeout;
+  } else if ([name isEqualToString:@"underline"]) {
+    return PSPDFAnnotationStringUnderline;
+  } else if ([name isEqualToString:@"squiggly"]) {
+    return PSPDFAnnotationMenuSquiggle;
+  } else if ([name isEqualToString:@"note"]) {
+    return PSPDFAnnotationStringNote;
+  } else if ([name isEqualToString:@"freetext"]) {
+    return PSPDFAnnotationStringFreeText;
+  } else if ([name isEqualToString:@"ink"]) {
+    return PSPDFAnnotationStringInk;
+  } else if ([name isEqualToString:@"square"]) {
+    return PSPDFAnnotationStringSquare;
+  } else if ([name isEqualToString:@"circle"]) {
+    return PSPDFAnnotationStringCircle;
+  } else if ([name isEqualToString:@"line"]) {
+    return PSPDFAnnotationStringLine;
+  } else if ([name isEqualToString:@"polygon"]) {
+    return PSPDFAnnotationStringPolygon;
+  } else if ([name isEqualToString:@"polyline"]) {
+    return PSPDFAnnotationStringPolyLine;
+  } else if ([name isEqualToString:@"signature"]) {
+    return PSPDFAnnotationStringSignature;
+  } else if ([name isEqualToString:@"stamp"]) {
+    return PSPDFAnnotationStringStamp;
+  } else if ([name isEqualToString:@"eraser"]) {
+    return PSPDFAnnotationStringEraser;
+  } else if ([name isEqualToString:@"sound"]) {
+    return PSPDFAnnotationStringSound;
+  } else if ([name isEqualToString:@"image"]) {
+    return PSPDFAnnotationStringImage;
+  } else if ([name isEqualToString:@"redaction"]) {
+    return PSPDFAnnotationStringRedaction;
+  }
+  
+  return nil;
+}
+
+@end

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -11,6 +11,7 @@
 #import "RCTConvert+PSPDFAnnotation.h"
 #import "RCTConvert+PSPDFConfiguration.h"
 #import "RCTConvert+PSPDFDocument.h"
+#import "RCTConvert+PSPDFAnnotationToolbarConfiguration.h"
 #import "RCTPSPDFKitView.h"
 #import <React/RCTUIManager.h>
 
@@ -47,6 +48,13 @@ RCT_CUSTOM_VIEW_PROPERTY(annotationAuthorName, pdfController.document.defaultAnn
   if (json) {
     view.pdfController.document.defaultAnnotationUsername = json;
     view.annotationAuthorName = json;
+  }
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(menuItemGrouping, PSPDFAnnotationToolbarConfiguration, RCTPSPDFKitView) {
+  if (json) {
+    PSPDFAnnotationToolbarConfiguration *configuration = [RCTConvert PSPDFAnnotationToolbarConfiguration:json];
+    view.pdfController.annotationToolbarController.annotationToolbar.configurations = @[configuration];
   }
 }
 

--- a/samples/Catalog/Catalog.android.js
+++ b/samples/Catalog/Catalog.android.js
@@ -331,6 +331,7 @@ class PdfViewScreen extends Component<{}> {
           }}
           pageIndex={this.state.currentPageIndex}
           fragmentTag="PDF1"
+          menuItemGrouping={['freetext', {key: 'markup', items: ['highlight', "underline"]}, 'ink', 'image']}
           onStateChanged={event => {
             this.setState({
               currentPageIndex: event.currentPageIndex,

--- a/samples/Catalog/Catalog.ios.js
+++ b/samples/Catalog/Catalog.ios.js
@@ -473,6 +473,7 @@ class AnnotationCreationMode extends Component {
             thumbnailBarMode: "scrollable",
             useParentNavigationBar: true
           }}
+          menuItemGrouping={['freetext', {key: 'markup', items: ['highlight', "underline"]}, 'ink', 'image']}
           pageIndex={this.state.currentPageIndex}
           style={{ flex: 1, color: pspdfkitColor }}
           onStateChanged={event => {


### PR DESCRIPTION
This adds a `menuItemGrouping` prop to the `PSPDFKitView`.
This works on both iOS and Android using platform independent naming for the menu items.