### PR TITLE
Unify configuration settings

### DIFF
--- a/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFConfiguration.m
+++ b/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFConfiguration.m
@@ -355,6 +355,10 @@ RCT_MULTI_ENUM_CONVERTER(PSPDFDocumentSharingPagesOptions,
   SET(settingsOptions, PSPDFSettingsOptions)
   SET(editableAnnotationTypes, NSSet)
 
+  if (dictionary[@"inlineSearch"]) {
+    self.searchMode = [RCTConvert BOOL:dictionary[@"inlineSearch"]] ? PSPDFSearchModeInline : PSPDFSearchModeModal;
+  }
+
   if (dictionary[@"sharingConfigurations"]) {
     [self setRCTSharingConfigurations:[RCTConvert NSArray:dictionary[@"sharingConfigurations"]]];
   }

--- a/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFConfiguration.m
+++ b/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFConfiguration.m
@@ -268,6 +268,7 @@ RCT_MULTI_ENUM_CONVERTER(PSPDFDocumentSharingPagesOptions,
 @end
 
 #define SET(property, type) if (dictionary[@#property]) self.property = [RCTConvert type:dictionary[@#property]];
+#define SET_PROPERTY(reactProperty, property, type) if (dictionary[@#reactProperty]) self.property = [RCTConvert type:dictionary[@#reactProperty]];
 #define SET_OBJECT(object, property, type) if (dictionary[@#property]) object.property = [RCTConvert type:dictionary[@#property]];
 
 @implementation PSPDFConfigurationBuilder (RNAdditions)
@@ -293,8 +294,11 @@ RCT_MULTI_ENUM_CONVERTER(PSPDFDocumentSharingPagesOptions,
   SET(allowedMenuActions, PSPDFTextSelectionMenuAction)
   SET(userInterfaceViewMode, PSPDFUserInterfaceViewMode)
   SET(userInterfaceViewAnimation, PSPDFUserInterfaceViewAnimation)
+  SET_PROPERTY(showThumbnailBar, thumbnailBarMode, PSPDFThumbnailBarMode)
   SET(thumbnailBarMode, PSPDFThumbnailBarMode)
+  SET_PROPERTY(showPageLabels, pageLabelEnabled, BOOL)
   SET(pageLabelEnabled, BOOL)
+  SET_PROPERTY(showDocumentLabel, documentLabelEnabled, PSPDFAdaptiveConditional)
   SET(documentLabelEnabled, PSPDFAdaptiveConditional)
   SET(shouldHideUserInterfaceOnPageChange, BOOL)
   SET(shouldShowUserInterfaceOnViewWillAppear, BOOL)
@@ -305,6 +309,7 @@ RCT_MULTI_ENUM_CONVERTER(PSPDFDocumentSharingPagesOptions,
   SET(scrubberBarType, PSPDFScrubberBarType)
   SET(thumbnailGrouping, PSPDFThumbnailGrouping)
   SET(pageTransition, PSPDFPageTransition)
+  SET_PROPERTY(pageScrollDirection, scrollDirection, PSPDFScrollDirection)
   SET(scrollDirection, PSPDFScrollDirection)
   SET(scrollViewInsetAdjustment, PSPDFScrollInsetAdjustment)
   SET(firstPageAlwaysSingle, BOOL)

--- a/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFConfiguration.m
+++ b/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFConfiguration.m
@@ -359,6 +359,10 @@ RCT_MULTI_ENUM_CONVERTER(PSPDFDocumentSharingPagesOptions,
     self.searchMode = [RCTConvert BOOL:dictionary[@"inlineSearch"]] ? PSPDFSearchModeInline : PSPDFSearchModeModal;
   }
 
+  if (dictionary[@"enableAnnotationEditing"] && [RCTConvert BOOL:dictionary[@"enableAnnotationEditing"]]) {
+    self.editableAnnotationTypes = nil;
+  }
+
   if (dictionary[@"sharingConfigurations"]) {
     [self setRCTSharingConfigurations:[RCTConvert NSArray:dictionary[@"sharingConfigurations"]]];
   }

--- a/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFConfiguration.m
+++ b/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFConfiguration.m
@@ -53,8 +53,10 @@ RCT_ENUM_CONVERTER(PSPDFLinkAction,
 
 RCT_ENUM_CONVERTER(PSPDFUserInterfaceViewMode,
                    (@{@"always" : @(PSPDFUserInterfaceViewModeAlways),
+                      @"alwaysVisible" : @(PSPDFUserInterfaceViewModeAlways),
                       @"automatic" : @(PSPDFUserInterfaceViewModeAutomatic),
                       @"automaticNoFirstLastPage" : @(PSPDFUserInterfaceViewModeAutomaticNoFirstLastPage),
+                      @"alwaysHidden" : @(PSPDFUserInterfaceViewModeNever),
                       @"never" : @(PSPDFUserInterfaceViewModeNever)}),
                    PSPDFUserInterfaceViewModeAutomatic,
                    unsignedIntegerValue)
@@ -68,6 +70,7 @@ RCT_ENUM_CONVERTER(PSPDFUserInterfaceViewAnimation,
 
 RCT_ENUM_CONVERTER(PSPDFThumbnailBarMode,
                    (@{@"none" : @(PSPDFThumbnailBarModeNone),
+                      @"default": @(PSPDFThumbnailBarModeScrubberBar),
                       @"scrubberBar" : @(PSPDFThumbnailBarModeScrubberBar),
                       @"scrollable" : @(PSPDFThumbnailBarModeScrollable)}),
                    PSPDFThumbnailBarModeNone,

--- a/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFConfiguration.m
+++ b/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFConfiguration.m
@@ -281,6 +281,7 @@ RCT_MULTI_ENUM_CONVERTER(PSPDFDocumentSharingPagesOptions,
   SET(scrollOnTapPageEndEnabled, BOOL)
   SET(scrollOnTapPageEndAnimationEnabled, BOOL)
   SET(scrollOnTapPageEndMargin, CGFloat)
+  SET_PROPERTY(enableTextSelection, textSelectionEnabled, BOOL)
   SET(textSelectionEnabled, BOOL)
   SET(imageSelectionEnabled, BOOL)
   SET(textSelectionMode, PSPDFTextSelectionMode)

--- a/samples/Catalog/Catalog.ios.js
+++ b/samples/Catalog/Catalog.ios.js
@@ -70,11 +70,13 @@ var examples = [
       "You can configure the controller with dictionary representation of the PSPDFConfiguration object.",
     action: () => {
       PSPDFKit.present("PDFs/Annual Report.pdf", {
-        scrollDirection: "horizontal",
+        pageScrollDirection: "horizontal",
         backgroundColor: processColor("white"),
-        thumbnailBarMode: "scrollable",
+        showThumbnailBar: "scrollable",
         pageTransition: "scrollContinuous",
-        scrollDirection: "vertical"
+        pageScrollDirection: "vertical",
+        showPageLabels: false,
+        showDocumentLabel: true
       });
     }
   },
@@ -88,7 +90,8 @@ var examples = [
         passProps: {
           document: "PDFs/Annual Report.pdf",
           configuration: {
-            useParentNavigationBar: true
+            useParentNavigationBar: true,
+            showDocumentLabel: true,  
           },
           style: { flex: 1 }
         }
@@ -182,11 +185,11 @@ var examples = [
       "Customize the sharing options for a document.",
     action: () => {
       PSPDFKit.present("PDFs/Annual Report.pdf", {
-        scrollDirection: "horizontal",
+        pageScrollDirection: "horizontal",
         backgroundColor: processColor("white"),
-        thumbnailBarMode: "scrollable",
+        showThumbnailBar: "scrollable",
         pageTransition: "scrollContinuous",
-        scrollDirection: "vertical",
+        pageScrollDirection: "vertical",
         sharingConfigurations: [
         	{
         		annotationOptions: ["flatten"],
@@ -293,7 +296,7 @@ class SplitPDF extends Component {
           document={"PDFs/Annual Report.pdf"}
           configuration={{
             backgroundColor: processColor("lightgrey"),
-            thumbnailBarMode: "scrollable"
+            showThumbnailBar: "scrollable"
           }}
           pageIndex={4}
           showCloseButton={true}
@@ -304,7 +307,7 @@ class SplitPDF extends Component {
           document={"PDFs/Business Report.pdf"}
           configuration={{
             pageTransition: "scrollContinuous",
-            scrollDirection: "vertical",
+            pageScrollDirection: "vertical",
             pageMode: "single"
           }}
           style={{ flex: 1, color: "#9932CC" }}
@@ -334,7 +337,7 @@ class EventListeners extends Component {
           document={"PDFs/Annual Report.pdf"}
           configuration={{
             backgroundColor: processColor("lightgrey"),
-            thumbnailBarMode: "scrollable",
+            showThumbnailBar: "scrollable",
             useParentNavigationBar: true
           }}
           style={{ flex: 1, color: pspdfkitColor }}
@@ -387,7 +390,7 @@ class ChangePages extends Component {
           document={"PDFs/Annual Report.pdf"}
           configuration={{
             backgroundColor: processColor("lightgrey"),
-            thumbnailBarMode: "scrollable",
+            showThumbnailBar: "scrollable",
             useParentNavigationBar: true
           }}
           pageIndex={this.state.currentPageIndex}
@@ -470,7 +473,7 @@ class AnnotationCreationMode extends Component {
           document={"PDFs/Annual Report.pdf"}
           configuration={{
             backgroundColor: processColor("lightgrey"),
-            thumbnailBarMode: "scrollable",
+            showThumbnailBar: "scrollable",
             useParentNavigationBar: true
           }}
           menuItemGrouping={['freetext', {key: 'markup', items: ['highlight', "underline"]}, 'ink', 'image']}
@@ -522,7 +525,7 @@ class ManualSave extends Component {
           disableAutomaticSaving={true}
           configuration={{
             backgroundColor: processColor("lightgrey"),
-            thumbnailBarMode: "scrollable",
+            showThumbnailBar: "scrollable",
             useParentNavigationBar: true
           }}
           style={{ flex: 1, color: pspdfkitColor }}
@@ -566,7 +569,7 @@ class ProgrammaticAnnotations extends Component {
           disableAutomaticSaving={true}
           configuration={{
             backgroundColor: processColor("lightgrey"),
-            thumbnailBarMode: "scrollable",
+            showThumbnailBar: "scrollable",
             useParentNavigationBar: true
           }}
           style={{ flex: 1, color: pspdfkitColor }}
@@ -812,7 +815,7 @@ class ProgrammaticFormFilling extends Component {
           disableAutomaticSaving={true}
           configuration={{
             backgroundColor: processColor("lightgrey"),
-            thumbnailBarMode: "scrollable",
+            showThumbnailBar: "scrollable",
             useParentNavigationBar: true
           }}
           style={{ flex: 1, color: pspdfkitColor }}

--- a/samples/Catalog/Catalog.ios.js
+++ b/samples/Catalog/Catalog.ios.js
@@ -76,7 +76,8 @@ var examples = [
         pageTransition: "scrollContinuous",
         pageScrollDirection: "vertical",
         showPageLabels: false,
-        showDocumentLabel: true
+        showDocumentLabel: true,
+        inlineSearch: true
       });
     }
   },


### PR DESCRIPTION
## Details

This PR unifies the configuration settings, so that we use the same property on all platforms. We decided to support both names on iOS because the implementation is easier. For example, on iOS we will support both `documentLabelEnabled` and `showDocumentLabel` when passed from JS code. We decided to support both to keep compatibility, but we will use the cross platform properties in our Catalog examples. 

## Acceptance Criteria

- [x] There are no platform-specific configuration properties left.
- [x] The iOS Catalog example uses the cross platform configuration properties instead of the specific ones.
- [x] This PR does not impact Android. 
- [x] This PR does not impact Windows. 