### PR TITLE
Add permissions in the info.plist of the iOS Catalog

### DIFF
--- a/samples/Catalog/ios/Catalog/Info.plist
+++ b/samples/Catalog/ios/Catalog/Info.plist
@@ -22,6 +22,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAllowsArbitraryLoadsInWebContent</key>
+	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>
@@ -35,6 +37,18 @@
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
+	<key>NSCameraUsageDescription</key>
+	<string>Pictures captured with the camera can be added to the document as image annotations.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Recording sound annotations requires the microphone.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Images from documents and annotations can be saved to the photo library.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Pictures from the photo library can be added to the document as image annotations.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
Adding the Camera, Photo Library, microphone, etc. permissions from https://pspdfkit.com/guides/ios/current/getting-started/permissions/#putting-it-all-together.