### PR TITLE
Add promise to save document and interaction mode

### DIFF
--- a/index.windows.js
+++ b/index.windows.js
@@ -24,8 +24,6 @@ class PSPDFKitView extends React.Component {
         ref="pdfView"
         {...this.props}
         onAnnotationsChanged={this._onAnnotationsChanged}
-        onDocumentSaved={this._onDocumentSaved}
-        onDocumentSaveFailed={this._onDocumentSaveFailed}
         onDataReturned={this._onDataReturned}
         onOperationResult={this._onOperationResult}
       />
@@ -35,18 +33,6 @@ class PSPDFKitView extends React.Component {
   _onAnnotationsChanged = event => {
     if (this.props.onAnnotationsChanged) {
       this.props.onAnnotationsChanged(event.nativeEvent);
-    }
-  };
-
-  _onDocumentSaved = event => {
-    if (this.props.onDocumentSaved) {
-      this.props.onDocumentSaved(event.nativeEvent);
-    }
-  };
-
-  _onDocumentSaveFailed = event => {
-    if (this.props.onDocumentSaveFailed) {
-      this.props.onDocumentSaveFailed(event.nativeEvent);
     }
   };
 
@@ -74,35 +60,71 @@ class PSPDFKitView extends React.Component {
 
   /**
    * Enters the annotation creation mode, showing the annotation creation toolbar.
+   *
+   * @returns a promise resolving if successful or rejects if an error occurs with and error message
    */
   enterAnnotationCreationMode() {
+    let requestId = this._nextRequestId++;
+    let requestMap = this._requestMap;
+
+    // We create a promise here that will be resolved once onDataReturned is called.
+    let promise = new Promise((resolve, reject) => {
+      requestMap[requestId] = { resolve: resolve, reject: reject };
+    });
+
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.refs.pdfView),
       UIManager.RCTPSPDFKitView.Commands.enterAnnotationCreationMode,
-      []
+      [requestId]
     );
+
+    return promise;
   }
 
   /**
    * Exits the currently active mode, hiding all active sub-toolbars.
+   *
+   * @returns a promise resolving if successful or rejects if an error occurs with and error message
    */
   exitCurrentlyActiveMode() {
+    let requestId = this._nextRequestId++;
+    let requestMap = this._requestMap;
+
+    // We create a promise here that will be resolved once onDataReturned is called.
+    let promise = new Promise((resolve, reject) => {
+      requestMap[requestId] = { resolve: resolve, reject: reject };
+    });
+
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.refs.pdfView),
       UIManager.RCTPSPDFKitView.Commands.exitCurrentlyActiveMode,
       []
     );
+
+    return promise;
   }
 
   /**
    * Saves the currently opened document.
+   *
+   * @returns a promise resolving if successful or rejects if an error occurs with and error message
    */
   saveCurrentDocument() {
+    let requestId = this._nextRequestId++;
+    let requestMap = this._requestMap;
+
+    // We create a promise here that will be resolved once onDataReturned is called.
+    let promise = new Promise((resolve, reject) => {
+      requestMap[requestId] = { resolve: resolve, reject: reject };
+    });
+
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.refs.pdfView),
       UIManager.RCTPSPDFKitView.Commands.saveCurrentDocument,
-      []
+      [requestId]
     );
+
+    return promise;
   }
 
   /**
@@ -137,17 +159,14 @@ class PSPDFKitView extends React.Component {
    * @param annotation InstantJson of the annotation to add with the format of
    * https://pspdfkit.com/guides/windows/current/importing-exporting/instant-json/#instant-annotation-json-api
    *
-   * @returns a promise resolving with a successful payload if annotation is created.
-   * {'success' : boolean}
-   * If success is false an error will also be held.
-   * {'error' : string}
+   * @returns a promise resolving if successful or rejects if an error occurs with and error message
    */
   addAnnotation(annotation) {
     let requestId = this._nextRequestId++;
     let requestMap = this._requestMap;
 
     // We create a promise here that will be resolved once onDataReturned is called.
-    let promise = new Promise(function (resolve, reject) {
+    let promise = new Promise((resolve, reject) => {
       requestMap[requestId] = {resolve: resolve, reject: reject};
     });
 

--- a/index.windows.js
+++ b/index.windows.js
@@ -69,7 +69,7 @@ class PSPDFKitView extends React.Component {
 
     // We create a promise here that will be resolved once onDataReturned is called.
     let promise = new Promise((resolve, reject) => {
-      requestMap[requestId] = { resolve: resolve, reject: reject };
+      requestMap[requestId] = {resolve: resolve, reject: reject};
     });
 
     UIManager.dispatchViewManagerCommand(
@@ -92,7 +92,7 @@ class PSPDFKitView extends React.Component {
 
     // We create a promise here that will be resolved once onDataReturned is called.
     let promise = new Promise((resolve, reject) => {
-      requestMap[requestId] = { resolve: resolve, reject: reject };
+      requestMap[requestId] = {resolve: resolve, reject: reject};
     });
 
     UIManager.dispatchViewManagerCommand(
@@ -115,7 +115,7 @@ class PSPDFKitView extends React.Component {
 
     // We create a promise here that will be resolved once onDataReturned is called.
     let promise = new Promise((resolve, reject) => {
-      requestMap[requestId] = { resolve: resolve, reject: reject };
+      requestMap[requestId] = {resolve: resolve, reject: reject};
     });
 
     UIManager.dispatchViewManagerCommand(

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -328,7 +328,11 @@ class PdfViewListenersScreen extends Component<{}> {
 
   componentWillMount() {
     this.props.navigation.setParams({
-      handleSaveButtonPress: () => this.refs.pdfView.saveCurrentDocument()
+      handleSaveButtonPress: () => this.refs.pdfView.saveCurrentDocument().then(() => {
+        alert("Document was saved!");
+      }).catch(error => {
+        alert(error);
+      })
     });
   }
 
@@ -340,15 +344,6 @@ class PdfViewListenersScreen extends Component<{}> {
           style={styles.pdfView}
           // The default file to open.
           document="ms-appx:///Assets/pdf/annualReport.pdf"
-          onDocumentSaved={e => {
-            alert("Document was saved!");
-          }}
-          onDocumentSaveFailed={e => {
-            alert("Document couldn't be saved: " + e.error);
-          }}
-          onAnnotationTapped={e => {
-            alert("Annotation was tapped\n" + JSON.stringify(e));
-          }}
           onAnnotationsChanged={e => {
             alert("Annotations changed\n" + JSON.stringify(e));
           }}

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PDFViewPage.xaml.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PDFViewPage.xaml.cs
@@ -27,7 +27,7 @@ namespace ReactNativePSPDFKit
         private StorageFile _fileToOpen;
         private bool _pdfViewInitialised = false;
         public readonly PdfView Pdfview;
-        
+
         public PDFViewPage()
         {
             InitializeComponent();
@@ -70,7 +70,7 @@ namespace ReactNativePSPDFKit
             _fileToOpen = file;
 
             // If the PdfView is already initialised we can show the new document.
-            if(_pdfViewInitialised)
+            if (_pdfViewInitialised)
             {
                 try
                 {
@@ -85,27 +85,19 @@ namespace ReactNativePSPDFKit
             }
         }
 
-        internal async Task ExportCurrentDocument()
+        internal async Task ExportCurrentDocument(int requestId)
         {
-            try
-            {
-                // Get the StorageFile
-                if (_fileToOpen != null)
+            await RunOperationAndFireEvent(requestId,
+                async () =>
                 {
-                    // Save it.
-                    await PDFView.Document.ExportAsync(_fileToOpen);
+                    // Get the StorageFile
+                    if (_fileToOpen != null)
+                    {
+                        // Save it.
+                        await PDFView.Document.ExportAsync(_fileToOpen);
+                    }
                 }
-
-                this.GetReactContext().GetNativeModule<UIManagerModule>().EventDispatcher.DispatchEvent(
-                    new PdfViewDocumentSavedEvent(this.GetTag())
-                );
-            }
-            catch (Exception e)
-            {
-                this.GetReactContext().GetNativeModule<UIManagerModule>().EventDispatcher.DispatchEvent(
-                    new PdfViewDocumentSaveFailedEvent(this.GetTag(), e.Message)
-                );
-            }
+            );
         }
 
         internal async Task GetAnnotations(int requestId, int pageIndex)
@@ -148,7 +140,8 @@ namespace ReactNativePSPDFKit
         {
             try
             {
-                var toolbarItems = PSPDFKit.UI.ToolbarComponents.Factory.FromJsonArray(JsonArray.Parse(toolbarItemsJson));
+                var toolbarItems =
+                    PSPDFKit.UI.ToolbarComponents.Factory.FromJsonArray(JsonArray.Parse(toolbarItemsJson));
                 await Pdfview.Controller.SetToolbarItemsAsync(toolbarItems.ToList());
             }
             catch (Exception e)
@@ -159,11 +152,29 @@ namespace ReactNativePSPDFKit
             }
         }
 
-        public async Task CreateAnnotation(int requestId, string annotationJsonString)
+        internal async Task CreateAnnotation(int requestId, string annotationJsonString)
+        {
+            await RunOperationAndFireEvent(requestId,
+                async () =>
+                {
+                    await Pdfview.Document.CreateAnnotationAsync(
+                        Factory.FromJson(JsonObject.Parse(annotationJsonString)));
+                }
+            );
+        }
+
+        internal async Task SetInteractionMode(int requestId, InteractionMode interactionMode)
+        {
+            await RunOperationAndFireEvent(requestId,
+                async () => { await Pdfview.Controller.SetInteractionModeAsync(interactionMode); }
+            );
+        }
+
+        private async Task RunOperationAndFireEvent(int requestId, Func<Task> operation)
         {
             try
             {
-                await Pdfview.Document.CreateAnnotationAsync(Factory.FromJson(JsonObject.Parse(annotationJsonString)));
+                await operation();
 
                 this.GetReactContext().GetNativeModule<UIManagerModule>().EventDispatcher.DispatchEvent(
                     new PdfViewOperationResult(this.GetTag(), requestId)
@@ -179,7 +190,7 @@ namespace ReactNativePSPDFKit
 
         internal async Task SetPageIndexAsync(int index)
         {
-           await PDFView.Controller.SetCurrentPageIndexAsync(index);
+            await PDFView.Controller.SetCurrentPageIndexAsync(index);
         }
 
         internal void SetShowToolbar(bool showToolbar)
@@ -194,6 +205,7 @@ namespace ReactNativePSPDFKit
             {
                 await PDFView.OpenStorageFileAsync(_fileToOpen);
             }
+
             _pdfViewInitialised = true;
         }
 
@@ -202,9 +214,9 @@ namespace ReactNativePSPDFKit
             foreach (var annotation in annotationList)
             {
                 this.GetReactContext().GetNativeModule<UIManagerModule>().EventDispatcher.DispatchEvent(
-                        new PdfViewAnnotationChangedEvent(this.GetTag(),
-                            PdfViewAnnotationChangedEvent.EVENT_TYPE_ADDED, annotation)
-                    );
+                    new PdfViewAnnotationChangedEvent(this.GetTag(),
+                        PdfViewAnnotationChangedEvent.EVENT_TYPE_ADDED, annotation)
+                );
             }
         }
 
@@ -213,9 +225,9 @@ namespace ReactNativePSPDFKit
             foreach (var annotation in annotationList)
             {
                 this.GetReactContext().GetNativeModule<UIManagerModule>().EventDispatcher.DispatchEvent(
-                        new PdfViewAnnotationChangedEvent(this.GetTag(),
-                            PdfViewAnnotationChangedEvent.EVENT_TYPE_CHANGED, annotation)
-                    );
+                    new PdfViewAnnotationChangedEvent(this.GetTag(),
+                        PdfViewAnnotationChangedEvent.EVENT_TYPE_CHANGED, annotation)
+                );
             }
         }
 
@@ -224,9 +236,9 @@ namespace ReactNativePSPDFKit
             foreach (var annotation in annotationList)
             {
                 this.GetReactContext().GetNativeModule<UIManagerModule>().EventDispatcher.DispatchEvent(
-                        new PdfViewAnnotationChangedEvent(this.GetTag(),
-                            PdfViewAnnotationChangedEvent.EVENT_TYPE_REMOVED, annotation)
-                    );
+                    new PdfViewAnnotationChangedEvent(this.GetTag(),
+                        PdfViewAnnotationChangedEvent.EVENT_TYPE_REMOVED, annotation)
+                );
             }
         }
     }

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitViewManager.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitViewManager.cs
@@ -93,13 +93,13 @@ namespace ReactNativePSPDFKit
             switch (commandId)
             {
                 case COMMAND_ENTER_ANNOTATION_CREATION_MODE:
-                    await PdfViewPage.Pdfview.Controller.SetInteractionModeAsync(InteractionMode.Note);
+                    await PdfViewPage.SetInteractionMode(args[0].Value<int>(), InteractionMode.Note);
                     break;
                 case COMMAND_EXIT_CURRENTLY_ACTIVE_MODE:
-                    await PdfViewPage.Pdfview.Controller.SetInteractionModeAsync(InteractionMode.None);
+                    await PdfViewPage.SetInteractionMode(args[0].Value<int>(), InteractionMode.None);
                     break;
                 case COMMAND_SAVE_CURRENT_DOCUMENT:
-                    await PdfViewPage.ExportCurrentDocument();
+                    await PdfViewPage.ExportCurrentDocument(args[0].Value<int>());
                     break;
                 case COMMAND_GET_ANNOTATIONS:
                     await PdfViewPage.GetAnnotations(args[0].Value<int>(), args[1].Value<int>());


### PR DESCRIPTION
Fixes : https://github.com/PSPDFKit/react-native/issues/169

These are the last operations that require to pass back a promise. 

The PR will change the contract for `saveCurrentDocument` which now directly returns a promise and will use the standard `OperationResult` like other none data returning types.