### PR TITLE
Support css colors

### DIFF
--- a/index.windows.js
+++ b/index.windows.js
@@ -11,22 +11,41 @@ import {
   requireNativeComponent,
   ViewPropTypes,
   findNodeHandle,
-  UIManager
+  UIManager,
+  processColor
 } from "react-native";
 
 class PSPDFKitView extends React.Component {
   _nextRequestId = 1;
   _requestMap = new Map();
 
+  state = {
+    pdfStyle: {
+      highlightColor: null,
+      primaryColor: null,
+      primaryDarkColor: null
+    }
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.state.pdfStyle = this._setPdfStyle(props.pdfStyle);
+  }
+
   render() {
     return (
       <RCTPSPDFKitView
         ref="pdfView"
-        {...this.props}
+        document={this.props.document}
+        pageIndex={this.props.pageIndex}
+        hideNavigationBar={this.props.hideNavigationBar}
+        onAnnotationsChanged={this.props.onAnnotationsChanged}
         onAnnotationsChanged={this._onAnnotationsChanged}
         onDataReturned={this._onDataReturned}
         onOperationResult={this._onOperationResult}
-      />
+        pdfStyle={this.state.pdfStyle}
+        style={this.props.style}/>
     );
   }
 
@@ -228,7 +247,31 @@ class PSPDFKitView extends React.Component {
 
     return promise;
   }
+
+  _setPdfStyle(colorObject)
+  {
+    var colorsToSend = {};
+    if (colorObject.highlightColor !== null) {
+      colorsToSend.highlightColor = processColor(colorObject.highlightColor);
+    }
+
+    if (colorObject.primaryColor !== null) {
+      colorsToSend.primaryColor = processColor(colorObject.primaryColor);
+    }
+
+    if (colorObject.primaryDarkColor !== null) {
+      colorsToSend.primaryDarkColor = processColor(colorObject.primaryDarkColor);
+    }
+
+    return colorsToSend;
+  }
 }
+
+const PDFStylePropTypes = PropTypes.shape({
+  highlightColor: PropTypes.string,
+  primaryColor: PropTypes.string,
+  primaryDarkColor: PropTypes.string
+});
 
 PSPDFKitView.propTypes = {
   /**
@@ -252,7 +295,18 @@ PSPDFKitView.propTypes = {
    * }
    */
   onAnnotationsChanged: PropTypes.func,
-  ...ViewPropTypes
+  /**
+   * Styles the pdf view in accordance to https://pspdfkit.com/guides/windows/current/customizing-the-interface/css-customization/
+   *
+   * Expects optional values of.
+   * {
+   *    highlightColor: PropTypes.string,
+   *    primaryColor: PropTypes.string,
+   *    primaryDarkColor: PropTypes.string
+   * }
+   */
+  pdfStyle: PDFStylePropTypes,
+  style: ViewPropTypes.style
 };
 
 const RCTPSPDFKitView = requireNativeComponent(

--- a/index.windows.js
+++ b/index.windows.js
@@ -26,7 +26,7 @@ class PSPDFKitView extends React.Component {
       primaryDarkColor: null
     },
     style: ViewPropTypes.style
-  }
+  };
 
   constructor(props) {
     super(props);
@@ -48,7 +48,6 @@ class PSPDFKitView extends React.Component {
         document={this.props.document}
         pageIndex={this.props.pageIndex}
         hideNavigationBar={this.props.hideNavigationBar}
-        onAnnotationsChanged={this.props.onAnnotationsChanged}
         onAnnotationsChanged={this._onAnnotationsChanged}
         onDataReturned={this._onDataReturned}
         onOperationResult={this._onOperationResult}

--- a/index.windows.js
+++ b/index.windows.js
@@ -292,10 +292,10 @@ PSPDFKitView.propTypes = {
    *
    * Expects optional values of.
    * {
-   *    highlightColor: PropTypes.string,
-   *    primaryColor: PropTypes.string,
-   *    primaryDarkColor: PropTypes.string
-   *    ...ViewPropTypes.style
+   *    highlightColor: PropTypes.string,  | Highlight or hover color.
+   *    primaryColor: PropTypes.string,    | Color for the main toolbar
+   *    primaryDarkColor: PropTypes.string | Color for the second toolbar
+   *    ...ViewPropTypes.style             | Standard style props
    * }
    */
   style: PDFStylePropTypes

--- a/index.windows.js
+++ b/index.windows.js
@@ -24,13 +24,21 @@ class PSPDFKitView extends React.Component {
       highlightColor: null,
       primaryColor: null,
       primaryDarkColor: null
-    }
+    },
+    style: ViewPropTypes.style
   }
 
   constructor(props) {
     super(props);
 
-    this.state.pdfStyle = this._setPdfStyle(props.pdfStyle);
+    this.state.pdfStyle.highlightColor = processColor(props.style.highlightColor);
+    delete props.style.highlightColor;
+    this.state.pdfStyle.primaryColor = processColor(props.style.primaryColor);
+    delete props.style.primaryColor;
+    this.state.pdfStyle.primaryDarkColor = processColor(props.style.primaryDarkColor);
+    delete props.style.primaryDarkColor;
+
+    this.state.style = props.style;
   }
 
   render() {
@@ -45,7 +53,7 @@ class PSPDFKitView extends React.Component {
         onDataReturned={this._onDataReturned}
         onOperationResult={this._onOperationResult}
         pdfStyle={this.state.pdfStyle}
-        style={this.props.style}/>
+        style={this.state.style}/>
     );
   }
 
@@ -247,30 +255,13 @@ class PSPDFKitView extends React.Component {
 
     return promise;
   }
-
-  _setPdfStyle(colorObject)
-  {
-    var colorsToSend = {};
-    if (colorObject.highlightColor !== null) {
-      colorsToSend.highlightColor = processColor(colorObject.highlightColor);
-    }
-
-    if (colorObject.primaryColor !== null) {
-      colorsToSend.primaryColor = processColor(colorObject.primaryColor);
-    }
-
-    if (colorObject.primaryDarkColor !== null) {
-      colorsToSend.primaryDarkColor = processColor(colorObject.primaryDarkColor);
-    }
-
-    return colorsToSend;
-  }
 }
 
 const PDFStylePropTypes = PropTypes.shape({
   highlightColor: PropTypes.string,
   primaryColor: PropTypes.string,
-  primaryDarkColor: PropTypes.string
+  primaryDarkColor: PropTypes.string,
+  ...ViewPropTypes.style
 });
 
 PSPDFKitView.propTypes = {
@@ -296,6 +287,7 @@ PSPDFKitView.propTypes = {
    */
   onAnnotationsChanged: PropTypes.func,
   /**
+   * Holds the standard style properties as expected plus extra pdf view style specific properties.
    * Styles the pdf view in accordance to https://pspdfkit.com/guides/windows/current/customizing-the-interface/css-customization/
    *
    * Expects optional values of.
@@ -303,10 +295,10 @@ PSPDFKitView.propTypes = {
    *    highlightColor: PropTypes.string,
    *    primaryColor: PropTypes.string,
    *    primaryDarkColor: PropTypes.string
+   *    ...ViewPropTypes.style
    * }
    */
-  pdfStyle: PDFStylePropTypes,
-  style: ViewPropTypes.style
+  style: PDFStylePropTypes
 };
 
 const RCTPSPDFKitView = requireNativeComponent(

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -86,7 +86,7 @@ const examples = [
   {
     key: "item1",
     name: "Open assets document",
-    description: "Open document from your project assets folder",
+    description: "Opens a document from your project assets folder",
     action: component => {
       component.props.navigation.navigate("PdfView");
     }
@@ -94,7 +94,7 @@ const examples = [
   {
     key: "item2",
     name: "Present a file from source",
-    description: "Open document from source",
+    description: "Opens a document from assets with Present",
     action: component => {
       component.props.navigation.navigate("PdfView");
       // Present can only take files loaded in the Visual studio Project's Assets. Please use RNFS.
@@ -172,6 +172,14 @@ const examples = [
     description: "An example to show how to customize the toolbar UI.",
     action: async component => {
       component.props.navigation.navigate("PdfViewToolbarCustomization");
+    }
+  },
+  {
+    key: "item8",
+      name: "Custom colors",
+      description: "Supplies different colors for Pdf View Toolbar.",
+      action: component => {
+      component.props.navigation.navigate("PdfViewStyle");
     }
   }
 ];
@@ -295,8 +303,7 @@ class PdfViewScreen extends Component<{}> {
           ref="pdfView"
           style={styles.pdfView}
           // The default file to open.
-          document="ms-appx:///Assets/pdf/annualReport.pdf"
-        />
+          document="ms-appx:///Assets/pdf/annualReport.pdf"/>
         <View style={styles.footer}>
           <View style={styles.button}>
             <Button onPress={() => PSPDFKit.OpenFilePicker()} title="Open"/>
@@ -443,6 +450,37 @@ class PdfViewToolbarCustomizationScreen extends Component<{}> {
   }
 }
 
+const pdfStyle = {
+  highlightColor: "#61D800", /* Hightlight or hover color. */
+  primaryColor: "red", /* Color for the main toolbar */
+  primaryDarkColor: "rgb(255, 0, 255)" /* Color for the second toolbar */
+};
+
+class PdfViewStyleScreen extends Component<{}> {
+  render() {
+    return (
+    <View style={styles.page}>
+      <PSPDFKitView
+    ref="pdfView"
+    style={styles.pdfView}
+          pdfStyle={pdfStyle}
+    // The default file to open.
+    document="ms-appx:///Assets/pdf/annualReport.pdf" />
+      <View style={styles.footer}>
+  <Image
+  source={require("./assets/logo-flat.png")}
+style={styles.logo}
+  />
+  <Text style={styles.version}>
+  SDK Version : {PSPDFKit.versionString}
+</Text>
+  </View>
+  </View>
+);
+}
+}
+
+
 export default StackNavigator(
   {
     Catalog: {
@@ -459,7 +497,10 @@ export default StackNavigator(
     },
     PdfViewToolbarCustomization: {
       screen: PdfViewToolbarCustomizationScreen
-    }
+    },
+    PdfViewStyle: {
+      screen: PdfViewStyleScreen
+    },
   },
   {
     initialRouteName: "Catalog"

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -184,6 +184,13 @@ const examples = [
   }
 ];
 
+const pdfStyle = {
+  flex: 1,
+  highlightColor: "#61D800", /* Hightlight or hover color. */
+  primaryColor: "red", /* Color for the main toolbar */
+  primaryDarkColor: "rgb(255, 0, 255)" /* Color for the second toolbar */
+};
+
 const styles = StyleSheet.create({
   page: {
     flex: 1,
@@ -450,20 +457,13 @@ class PdfViewToolbarCustomizationScreen extends Component<{}> {
   }
 }
 
-const pdfStyle = {
-  highlightColor: "#61D800", /* Hightlight or hover color. */
-  primaryColor: "red", /* Color for the main toolbar */
-  primaryDarkColor: "rgb(255, 0, 255)" /* Color for the second toolbar */
-};
-
 class PdfViewStyleScreen extends Component<{}> {
   render() {
     return (
     <View style={styles.page}>
       <PSPDFKitView
     ref="pdfView"
-    style={styles.pdfView}
-          pdfStyle={pdfStyle}
+          style={pdfStyle}
     // The default file to open.
     document="ms-appx:///Assets/pdf/annualReport.pdf" />
       <View style={styles.footer}>

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -186,7 +186,7 @@ const examples = [
 
 const pdfStyle = {
   flex: 1,
-  highlightColor: "#61D800", /* Hightlight or hover color. */
+  highlightColor: "#61D800", /* Highlight or hover color. */
   primaryColor: "red", /* Color for the main toolbar */
   primaryDarkColor: "rgb(255, 0, 255)" /* Color for the second toolbar */
 };

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -176,9 +176,9 @@ const examples = [
   },
   {
     key: "item8",
-      name: "Custom colors",
-      description: "Supplies different colors for Pdf View Toolbar.",
-      action: component => {
+    name: "Custom colors",
+    description: "Supplies different colors for Pdf View Toolbar.",
+    action: component => {
       component.props.navigation.navigate("PdfViewStyle");
     }
   }
@@ -460,24 +460,24 @@ class PdfViewToolbarCustomizationScreen extends Component<{}> {
 class PdfViewStyleScreen extends Component<{}> {
   render() {
     return (
-    <View style={styles.page}>
-      <PSPDFKitView
-    ref="pdfView"
+      <View style={styles.page}>
+        <PSPDFKitView
+          ref="pdfView"
           style={pdfStyle}
-    // The default file to open.
-    document="ms-appx:///Assets/pdf/annualReport.pdf" />
-      <View style={styles.footer}>
-  <Image
-  source={require("./assets/logo-flat.png")}
-style={styles.logo}
-  />
-  <Text style={styles.version}>
-  SDK Version : {PSPDFKit.versionString}
-</Text>
-  </View>
-  </View>
-);
-}
+          // The default file to open.
+          document="ms-appx:///Assets/pdf/annualReport.pdf"/>
+        <View style={styles.footer}>
+          <Image
+            source={require("./assets/logo-flat.png")}
+            style={styles.logo}
+          />
+          <Text style={styles.version}>
+            SDK Version : {PSPDFKit.versionString}
+          </Text>
+        </View>
+      </View>
+    );
+  }
 }
 
 

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/Assets/customTheme.css
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/Assets/customTheme.css
@@ -1,0 +1,6 @@
+/* Main Toolbar */
+@import url("pspdfkit/windows.css");
+
+:root {
+${colors}
+}

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/ColorUtils.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/ColorUtils.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI;
+
+namespace ReactNativePSPDFKit
+{
+    internal static class ColorUtils
+    {
+        /// <summary>
+        /// Converts a Color value to a string representation of the value in hexadecimal.
+        /// Drops the Alpha channel.
+        /// </summary>
+        /// <param name="color">The Color to convert.</param>
+        /// <returns>Returns a string representing the hex value.</returns>
+        public static string ToHexWithoutAlpha(this Color color)
+        {
+            return $"#{color.R:X2}{color.G:X2}{color.B:X2}";
+        }
+    }
+}

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitViewManager.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitViewManager.cs
@@ -11,11 +11,9 @@ using System;
 using ReactNative.UIManager;
 using ReactNative.UIManager.Annotations;
 using Windows.Storage;
-using Windows.UI;
 using Newtonsoft.Json.Linq;
 using PSPDFKit.UI;
 using ReactNativePSPDFKit.Events;
-using System.Text.RegularExpressions;
 
 namespace ReactNativePSPDFKit
 {
@@ -91,12 +89,12 @@ namespace ReactNativePSPDFKit
                 var cssTemplateString = await FileIO.ReadTextAsync(cssTemplate);
                 cssTemplateString = cssTemplateString.Replace("${colors}", colorString);
                 
-                //create file in temp folder
+                // We have to write a file in the temp folder due to permission issues.
                 var storageFolder = ApplicationData.Current.TemporaryFolder;
                 var sampleFile = await storageFolder.CreateFileAsync("windows.css", CreationCollisionOption.ReplaceExisting);
                 await FileIO.WriteTextAsync(sampleFile, cssTemplateString);
 
-                // Now we get the assets folder to copy the final css file into.
+                // Now we get the assets folder to copy the final css file into and move the previous file.
                 var appInstalledFolder = Windows.ApplicationModel.Package.Current.InstalledLocation;
                 var assetsFolder = await appInstalledFolder.GetFolderAsync("Assets");
                 await sampleFile.MoveAsync(assetsFolder, "windows.css", NameCollisionOption.ReplaceExisting);

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/ReactNativePSPDFKit.csproj
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/ReactNativePSPDFKit.csproj
@@ -106,6 +106,7 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="ColorUtils.cs" />
     <Compile Include="Events\PdfViewAnnotationChangedEvent.cs" />
     <Compile Include="Events\PdfViewDocumentSavedEvent.cs" />
     <Compile Include="Events\PdfViewDataReturnedEvent.cs" />
@@ -157,6 +158,12 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+  </ItemGroup>
+  <ItemGroup />
+  <ItemGroup>
+    <Content Include="Assets\customTheme.css">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>


### PR DESCRIPTION
Fixes https://github.com/PSPDFKit/react-native/issues/184

This will allow the users to set the 3 main colors used in the UI.

The props are now handled a little different, so we can do some custom processing. This way we can allow the users to pass in the extra colors as part of `style` and we split it out in `index.windows.js`. 

In the future it may be useful to allow the user to declare more css properties, or have an open css property to define any string, but validation on this will be hard and I imagine it's not a common use case.