### PR TITLE
Fix set toolbar promise.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.23.4",
+  "version": "1.23.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.23.4",
+  "version": "1.23.5",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -441,7 +441,9 @@ class PdfViewToolbarCustomizationScreen extends Component<{}> {
             </View>
             <View style={styles.button}>
               <Button onPress={() =>
-                this.refs.pdfView.setToolbarItems([{type: "ink"}])} title="Set Toolbar Items"/>
+                this.refs.pdfView.setToolbarItems([{ type: "ink" }]).then(() => {
+                  alert("Toolbar Items set.");
+                })} title="Set Toolbar Items"/>
             </View>
           </View>
           <Image

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -441,7 +441,7 @@ class PdfViewToolbarCustomizationScreen extends Component<{}> {
             </View>
             <View style={styles.button}>
               <Button onPress={() =>
-                this.refs.pdfView.setToolbarItems([{ type: "ink" }]).then(() => {
+                this.refs.pdfView.setToolbarItems([{type: "ink"}]).then(() => {
                   alert("Toolbar Items set.");
                 })} title="Set Toolbar Items"/>
             </View>

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.23.4",
+  "version": "1.23.5",
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start"

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PDFViewPage.xaml.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PDFViewPage.xaml.cs
@@ -138,18 +138,14 @@ namespace ReactNativePSPDFKit
 
         internal async Task SetToolbarItems(int requestId, string toolbarItemsJson)
         {
-            try
-            {
-                var toolbarItems =
-                    PSPDFKit.UI.ToolbarComponents.Factory.FromJsonArray(JsonArray.Parse(toolbarItemsJson));
-                await Pdfview.Controller.SetToolbarItemsAsync(toolbarItems.ToList());
-            }
-            catch (Exception e)
-            {
-                this.GetReactContext().GetNativeModule<UIManagerModule>().EventDispatcher.DispatchEvent(
-                    new PdfViewDataReturnedEvent(this.GetTag(), requestId, e.Message)
-                );
-            }
+            await RunOperationAndFireEvent(requestId,
+                async () =>
+                {
+                    var toolbarItems =
+                        PSPDFKit.UI.ToolbarComponents.Factory.FromJsonArray(JsonArray.Parse(toolbarItemsJson));
+                    await Pdfview.Controller.SetToolbarItemsAsync(toolbarItems.ToList());
+                }
+            );
         }
 
         internal async Task CreateAnnotation(int requestId, string annotationJsonString)


### PR DESCRIPTION
Fixes https://github.com/PSPDFKit/react-native/issues/207

# Details
Mistakenly did not handle the promise for set toolbar and therefore it was never fired. Same is true for the error.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
