### PR TITLE
Fix crash when null colors are passed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.23.8",
+  "version": "1.23.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.23.8",
+  "version": "1.23.9",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.23.8",
+  "version": "1.23.9",
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start"

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/JsonUtils.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/JsonUtils.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections.Generic;
+using Windows.UI;
 using Newtonsoft.Json.Linq;
 using PSPDFKit.Search;
 using PSPDFKitFoundation;
 using PSPDFKitFoundation.Search;
 using PSPDFKitNative;
+using ReactNative.UIManager;
 
 namespace ReactNativePSPDFKit
 {
@@ -130,6 +132,21 @@ namespace ReactNativePSPDFKit
             }
 
             return pageNumbersJson;
+        }
+
+        internal static Color? ParserColor(JObject jObject, string propertyName)
+        {
+            if (TryGetNotNullValue(jObject, propertyName, out var jsonHighlightColor))
+            {
+                return ColorHelpers.Parse(jsonHighlightColor.Value<uint>());
+            }
+
+            return null;
+        }
+
+        internal static bool TryGetNotNullValue(JObject jObject, string propertyName, out JToken value)
+        {
+            return jObject.TryGetValue(propertyName, out value) && value.Type != JTokenType.Null;
         }
     }
 }

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitViewManager.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitViewManager.cs
@@ -63,22 +63,23 @@ namespace ReactNativePSPDFKit
         public async void SetCustomCss(PDFViewPage view, JObject styleJObject)
         {
             var colorString = string.Empty;
-            if (styleJObject.ContainsKey("highlightColor"))
+
+            var maybeHighlightColor = JsonUtils.ParserColor(styleJObject, "highlightColor");
+            if (maybeHighlightColor.HasValue)
             {
-                var highlightColor = ColorHelpers.Parse(styleJObject["highlightColor"].Value<uint>());
-                colorString += $"    --primary: {highlightColor.ToHexWithoutAlpha()};\r\n";
+                colorString += $"    --primary: {maybeHighlightColor.Value.ToHexWithoutAlpha()};\r\n";
             }
 
-            if (styleJObject.ContainsKey("primaryColor"))
+            var maybePrimaryColor = JsonUtils.ParserColor(styleJObject, "primaryColor");
+            if (maybePrimaryColor.HasValue)
             {
-                var primaryColor = ColorHelpers.Parse(styleJObject["primaryColor"].Value<uint>());
-                colorString += $"    --primary-dark-1: {primaryColor.ToHexWithoutAlpha()};\r\n";
+                colorString += $"    --primary-dark-1: {maybePrimaryColor.Value.ToHexWithoutAlpha()};\r\n";
             }
 
-            if (styleJObject.ContainsKey("primaryDarkColor"))
+            var maybePrimaryDarkColor = JsonUtils.ParserColor(styleJObject, "primaryDarkColor");
+            if (maybePrimaryDarkColor.HasValue)
             {
-                var primaryDarkColor = ColorHelpers.Parse(styleJObject["primaryDarkColor"].Value<uint>());
-                colorString += $"    --primary-dark-2: {primaryDarkColor.ToHexWithoutAlpha()};\r\n";
+                colorString += $"    --primary-dark-2: {maybePrimaryDarkColor.Value.ToHexWithoutAlpha()};\r\n";
             }
 
             if (colorString.Length > 0)


### PR DESCRIPTION
Fixes : https://github.com/PSPDFKit/react-native/issues/215

# Details
JObject throws when checking for a `null` or `undefined` value. Instead of throwing we check for this and do not include the value allow the application to continue.

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
