### PR TITLE
Update wrapper to PSPSDFKit for Windows 2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.23.12",
+  "version": "1.23.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.23.12",
+  "version": "1.23.13",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -134,11 +134,6 @@ const examples = [
     action: async () => {
       await PSPDFKitLibrary.OpenLibrary("MyLibrary");
       await PSPDFKitLibrary.EnqueueDocumentsInFolderPicker("MyLibrary");
-      alert(
-        'Searching Library for "' +
-        simpleSearch.searchString +
-        '". Please wait.'
-      );
       PSPDFKitLibrary.SearchLibrary("MyLibrary", simpleSearch)
         .then(result => {
           alert("Search : \n" + JSON.stringify(result));
@@ -155,11 +150,6 @@ const examples = [
 
       await PSPDFKitLibrary.OpenLibrary("AssetsLibrary");
       await PSPDFKitLibrary.EnqueueDocumentsInFolder("AssetsLibrary", path);
-      alert(
-        'Searching Library for "' +
-        complexSearchConfiguration.searchString +
-        '". Please wait.'
-      );
       PSPDFKitLibrary.SearchLibrary("AssetsLibrary", complexSearchConfiguration)
         .then(result => {
           alert("Search : \n" + JSON.stringify(result));

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.23.12",
+  "version": "1.23.13",
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start"

--- a/samples/Catalog/windows/Catalog/Catalog.csproj
+++ b/samples/Catalog/windows/Catalog/Catalog.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.17134.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -246,7 +246,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.0.8</Version>
+      <Version>6.2.8</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
@@ -263,7 +263,7 @@
     <SDKReference Include="Microsoft.VCLibs, Version=14.0">
       <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
     </SDKReference>
-    <SDKReference Include="PSPDFKitSDK, Version=1.12.0">
+    <SDKReference Include="PSPDFKitSDK, Version=2.0.0">
       <Name>PSPDFKit for UWP</Name>
     </SDKReference>
   </ItemGroup>

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/JsonUtils.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/JsonUtils.cs
@@ -108,7 +108,7 @@ namespace ReactNativePSPDFKit
             return queryResultsJson;
         }
 
-        private static JToken RangeToJson(IRange range)
+        private static JToken RangeToJson(Range range)
         {
             return new JObject
             {
@@ -117,9 +117,9 @@ namespace ReactNativePSPDFKit
             };
         }
 
-        private static IRange ToRange(JToken rangeJson)
+        private static Range ToRange(JToken rangeJson)
         {
-            return new Range(rangeJson.Value<int>("postion"), rangeJson.Value<int>("length"));
+            return new Range(rangeJson.Value<int>("position"), rangeJson.Value<int>("length"));
         }
 
         private static JArray LibraryQueryReultToJson(LibraryQueryResult libraryQueryResult)

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/ReactNativePSPDFKit.csproj
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/ReactNativePSPDFKit.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17134.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -122,23 +122,23 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.0.8</Version>
+      <Version>6.2.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
-      <Version>4.0.0</Version>
+      <Version>5.1.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
-      <Version>2.0.0</Version>
+      <Version>2.0.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>11.0.2</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <SDKReference Include="Microsoft.VCLibs, Version=14.0">
       <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
     </SDKReference>
-    <SDKReference Include="PSPDFKitSDK, Version=1.12.0">
+    <SDKReference Include="PSPDFKitSDK, Version=2.0.0">
       <Name>PSPDFKit for UWP</Name>
     </SDKReference>
   </ItemGroup>


### PR DESCRIPTION
Update wrapper to PSPSDFKit for Windows 2.0

# Details
- Update references
- Make JsonUtils compatible.
- update all nuget versions.
- removed alert from library search example as this is more than fast enough now.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
