### PR TITLE
Align annotations changed with ios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.23.11",
+  "version": "1.23.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.23.11",
+  "version": "1.23.12",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.23.11",
+  "version": "1.23.12",
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start"

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/Events/PdfViewAnnotationChangedEvent.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/Events/PdfViewAnnotationChangedEvent.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json.Linq;
 using PSPDFKit.Pdf.Annotation;
 using ReactNative.UIManager.Events;
+using System.Collections.Generic;
 
 namespace ReactNativePSPDFKit.Events
 {
@@ -15,22 +16,28 @@ namespace ReactNativePSPDFKit.Events
         public const string EVENT_TYPE_REMOVED = "removed";
 
         private readonly string _eventType;
-        private readonly IAnnotation _annotation;
+        private readonly IList<IAnnotation> _annotations;
 
-        public PdfViewAnnotationChangedEvent(int viewId, string eventType, IAnnotation annotation) : base(viewId)
+        public PdfViewAnnotationChangedEvent(int viewId, string eventType, IList<IAnnotation> annotations) : base(viewId)
         {
-            this._eventType = eventType;
-            this._annotation = annotation;
+            _eventType = eventType;
+            _annotations = annotations;
         }
 
         public override string EventName => EVENT_NAME;
 
         public override void Dispatch(RCTEventEmitter rctEventEmitter)
         {
+            var annotationsJson = new JArray();
+            foreach (var annotation in _annotations)
+            {
+                annotationsJson.Add(JObject.Parse(annotation.ToJson().Stringify()));
+            }
+
             var eventData = new JObject
             {
                 { "change", _eventType },
-                { "annotations", JObject.Parse(_annotation.ToJson().Stringify()) }
+                { "annotations", annotationsJson }
             };
 
             rctEventEmitter.receiveEvent(ViewTag, EventName, eventData);

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PDFViewPage.xaml.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PDFViewPage.xaml.cs
@@ -216,37 +216,28 @@ namespace ReactNativePSPDFKit
             _pdfViewInitialised = true;
         }
 
-        private void DocumentOnAnnotationsCreated(object sender, IList<IAnnotation> annotationList)
+        private void DocumentOnAnnotationsCreated(object sender, IList<IAnnotation> annotations)
         {
-            foreach (var annotation in annotationList)
-            {
-                this.GetReactContext().GetNativeModule<UIManagerModule>().EventDispatcher.DispatchEvent(
-                    new PdfViewAnnotationChangedEvent(this.GetTag(),
-                        PdfViewAnnotationChangedEvent.EVENT_TYPE_ADDED, annotation)
-                );
-            }
+            this.GetReactContext().GetNativeModule<UIManagerModule>().EventDispatcher.DispatchEvent(
+                new PdfViewAnnotationChangedEvent(this.GetTag(),
+                    PdfViewAnnotationChangedEvent.EVENT_TYPE_ADDED, annotations)
+            );
         }
 
-        private void DocumentOnAnnotationsUpdated(object sender, IList<IAnnotation> annotationList)
+        private void DocumentOnAnnotationsUpdated(object sender, IList<IAnnotation> annotations)
         {
-            foreach (var annotation in annotationList)
-            {
-                this.GetReactContext().GetNativeModule<UIManagerModule>().EventDispatcher.DispatchEvent(
-                    new PdfViewAnnotationChangedEvent(this.GetTag(),
-                        PdfViewAnnotationChangedEvent.EVENT_TYPE_CHANGED, annotation)
-                );
-            }
+            this.GetReactContext().GetNativeModule<UIManagerModule>().EventDispatcher.DispatchEvent(
+                new PdfViewAnnotationChangedEvent(this.GetTag(),
+                    PdfViewAnnotationChangedEvent.EVENT_TYPE_CHANGED, annotations)
+            );
         }
 
-        private void DocumentOnAnnotationsDeleted(object sender, IList<IAnnotation> annotationList)
+        private void DocumentOnAnnotationsDeleted(object sender, IList<IAnnotation> annotations)
         {
-            foreach (var annotation in annotationList)
-            {
-                this.GetReactContext().GetNativeModule<UIManagerModule>().EventDispatcher.DispatchEvent(
-                    new PdfViewAnnotationChangedEvent(this.GetTag(),
-                        PdfViewAnnotationChangedEvent.EVENT_TYPE_REMOVED, annotation)
-                );
-            }
+            this.GetReactContext().GetNativeModule<UIManagerModule>().EventDispatcher.DispatchEvent(
+                new PdfViewAnnotationChangedEvent(this.GetTag(),
+                    PdfViewAnnotationChangedEvent.EVENT_TYPE_REMOVED, annotations)
+            );
         }
     }
 }

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitViewManager.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitViewManager.cs
@@ -8,14 +8,10 @@
 //
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using Windows.Data.Json;
 using ReactNative.UIManager;
 using ReactNative.UIManager.Annotations;
 using Windows.Storage;
 using Newtonsoft.Json.Linq;
-using PSPDFKit.Pdf.Annotation;
 using PSPDFKit.UI;
 using ReactNativePSPDFKit.Events;
 


### PR DESCRIPTION
Fixes : https://github.com/PSPDFKit/react-native/issues/196

# Details
This PR changes annotation events on UWP to pass back a list of annotations like Android and iOS does. 

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
