### PR TITLE
Add configuration for page mode and displaying the first page as a single page

### DIFF
--- a/android/src/main/java/com/pspdfkit/react/ConfigurationAdapter.java
+++ b/android/src/main/java/com/pspdfkit/react/ConfigurationAdapter.java
@@ -13,15 +13,15 @@
 
 package com.pspdfkit.react;
 
-import android.app.Activity;
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
-import com.pspdfkit.configuration.activity.UserInterfaceViewMode;
 import com.pspdfkit.configuration.activity.PdfActivityConfiguration;
 import com.pspdfkit.configuration.activity.ThumbnailBarMode;
+import com.pspdfkit.configuration.activity.UserInterfaceViewMode;
 import com.pspdfkit.configuration.page.PageFitMode;
 import com.pspdfkit.configuration.page.PageLayoutMode;
 import com.pspdfkit.configuration.page.PageScrollDirection;
@@ -305,9 +305,10 @@ public class ConfigurationAdapter {
         }
     }
 
-    private void configurePageMode(String pageMode) {
+    private void configurePageMode(@Nullable final String pageMode) {
         PageLayoutMode pageLayoutMode = PageLayoutMode.AUTO;
-        if (pageMode.equalsIgnoreCase(PAGE_MODE_AUTO)) {
+        if (pageMode == null ||
+            pageMode.equalsIgnoreCase(PAGE_MODE_AUTO)) {
             pageLayoutMode = PageLayoutMode.AUTO;
         } else if (pageMode.equalsIgnoreCase(PAGE_MODE_SINGLE)) {
             pageLayoutMode = PageLayoutMode.SINGLE;
@@ -317,7 +318,7 @@ public class ConfigurationAdapter {
         configuration.layoutMode(pageLayoutMode);
     }
 
-    private void configureFirstPageAlwaysSingle(boolean firstPageAlwaysSingle) {
+    private void configureFirstPageAlwaysSingle(final boolean firstPageAlwaysSingle) {
         configuration.firstPageAlwaysSingle(firstPageAlwaysSingle);
     }
 

--- a/android/src/main/java/com/pspdfkit/react/ConfigurationAdapter.java
+++ b/android/src/main/java/com/pspdfkit/react/ConfigurationAdapter.java
@@ -23,6 +23,7 @@ import com.pspdfkit.configuration.activity.UserInterfaceViewMode;
 import com.pspdfkit.configuration.activity.PdfActivityConfiguration;
 import com.pspdfkit.configuration.activity.ThumbnailBarMode;
 import com.pspdfkit.configuration.page.PageFitMode;
+import com.pspdfkit.configuration.page.PageLayoutMode;
 import com.pspdfkit.configuration.page.PageScrollDirection;
 import com.pspdfkit.configuration.page.PageScrollMode;
 
@@ -58,7 +59,11 @@ public class ConfigurationAdapter {
     private static final String SHOW_PRINT_ACTION = "showPrintAction";
     private static final String SHOW_DOCUMENT_INFO_VIEW = "showDocumentInfoView";
     private static final String SHOW_DOCUMENT_TITLE_OVERLAY = "documentLabelEnabled";
-
+    private static final String PAGE_MODE = "pageMode";
+    private static final String PAGE_MODE_SINGLE = "single";
+    private static final String PAGE_MODE_DOUBLE = "double";
+    private static final String PAGE_MODE_AUTO = "automatic";
+    private static final String FIRST_PAGE_ALWAYS_SINGLE = "firstPageAlwaysSingle";
 
     private final PdfActivityConfiguration.Builder configuration;
 
@@ -133,6 +138,12 @@ public class ConfigurationAdapter {
             }
             if (configuration.hasKey(SHOW_DOCUMENT_TITLE_OVERLAY)) {
                 configureShowDocumentTitleOverlay(configuration.getBoolean(SHOW_DOCUMENT_TITLE_OVERLAY));
+            }
+            if (configuration.hasKey(PAGE_MODE)) {
+                configurePageMode(configuration.getString(PAGE_MODE));
+            }
+            if (configuration.hasKey(FIRST_PAGE_ALWAYS_SINGLE)) {
+                configureFirstPageAlwaysSingle(configuration.getBoolean(FIRST_PAGE_ALWAYS_SINGLE));
             }
         }
     }
@@ -292,6 +303,22 @@ public class ConfigurationAdapter {
         } else {
             configuration.hideDocumentTitleOverlay();
         }
+    }
+
+    private void configurePageMode(String pageMode) {
+        PageLayoutMode pageLayoutMode = PageLayoutMode.AUTO;
+        if (pageMode.equalsIgnoreCase(PAGE_MODE_AUTO)) {
+            pageLayoutMode = PageLayoutMode.AUTO;
+        } else if (pageMode.equalsIgnoreCase(PAGE_MODE_SINGLE)) {
+            pageLayoutMode = PageLayoutMode.SINGLE;
+        } else if (pageMode.equalsIgnoreCase(PAGE_MODE_DOUBLE)) {
+            pageLayoutMode = PageLayoutMode.DOUBLE;
+        }
+        configuration.layoutMode(pageLayoutMode);
+    }
+
+    private void configureFirstPageAlwaysSingle(boolean firstPageAlwaysSingle) {
+        configuration.firstPageAlwaysSingle(firstPageAlwaysSingle);
     }
 
     public PdfActivityConfiguration build() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.23.14",
+  "version": "1.23.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.23.14",
+  "version": "1.23.15",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.23.14",
+  "version": "1.23.15",
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start"


### PR DESCRIPTION
## Resolves #225 

# Details

We were missing `pageMode` and related `firstPageAlwaysSingle` in the `ConfigurationAdapter` this adds those missing properties.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
