### PR TITLE
Create the PDFViewPage when asked to by react native.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.23.13",
+  "version": "1.23.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.23.13",
+  "version": "1.23.14",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.23.13",
+  "version": "1.23.14",
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start"

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PDFViewPage.xaml.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PDFViewPage.xaml.cs
@@ -39,6 +39,8 @@ namespace ReactNativePSPDFKit
                 // This is a work aronud to ensure that if the user navigates away from
                 // the Page and then back, a document will still be shown.
                 _fileToOpen = null;
+
+                args.Complete();
             };
 
             PDFView.OnDocumentOpened += (pdfView, document) =>

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitModule.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitModule.cs
@@ -22,12 +22,12 @@ namespace ReactNativePSPDFKit
     /// </summary>
     class PSPDFKitModule : ReactContextNativeModuleBase
     {
-        private readonly PDFViewPage _pdfViewPage;
+        private readonly PSPDFKitViewManger _viewManager;
         private string VERSION_KEY = "versionString";
 
-        public PSPDFKitModule(ReactContext reactContext, PDFViewPage pdfViewPage) : base(reactContext)
+        public PSPDFKitModule(ReactContext reactContext, PSPDFKitViewManger viewManager) : base(reactContext)
         {
-            _pdfViewPage = pdfViewPage;
+            _viewManager = viewManager;
         }
 
         /// <summary>
@@ -98,8 +98,14 @@ namespace ReactNativePSPDFKit
         private async Task LoadFileAsync(StorageFile file)
         {
             if (file == null) return;
-
-            await _pdfViewPage.OpenFileAsync(file);
+            if(_viewManager.PdfViewPage != null)
+            {
+                await _viewManager.PdfViewPage.OpenFileAsync(file);
+            }
+            else
+            {
+                throw new Exception("PdfViewPage: is not ready or unavailable.");
+            }
         }
 
         /// <summary>

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitPackage.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitPackage.cs
@@ -12,6 +12,7 @@ using ReactNative.Modules.Core;
 using ReactNative.UIManager;
 using System;
 using System.Collections.Generic;
+using Windows.UI.Xaml;
 
 namespace ReactNativePSPDFKit
 {
@@ -23,13 +24,14 @@ namespace ReactNativePSPDFKit
     /// </summary>
     public class PSPDFKitPackage : IReactPackage
     {
-        private readonly PSPDFKitViewManger _pspdfkitViewManger = new PSPDFKitViewManger();
+        private readonly PSPDFKitViewManger _pspdfkitViewManger;
 
         /// <summary>
         /// Creates a PSPDFKit package with the default settings.
         /// </summary>
         public PSPDFKitPackage()
         {
+            _pspdfkitViewManger = new PSPDFKitViewManger(null);
         }
 
         /// <summary>
@@ -38,7 +40,7 @@ namespace ReactNativePSPDFKit
         /// </summary>
         public PSPDFKitPackage(Uri cssResource)
         {
-            _pspdfkitViewManger.PdfViewPage.Pdfview.Css = cssResource;
+            _pspdfkitViewManger = new PSPDFKitViewManger(cssResource);
         }
 
         /// <summary>
@@ -51,8 +53,8 @@ namespace ReactNativePSPDFKit
         {
             return new List<INativeModule>
             {
-                new PSPDFKitModule(reactContext, _pspdfkitViewManger.PdfViewPage),
-                new LibraryModule(reactContext, _pspdfkitViewManger.PdfViewPage.Pdfview.License)
+                new PSPDFKitModule(reactContext, _pspdfkitViewManger),
+                new LibraryModule(reactContext, Application.Current.Resources["PSPDFKitLicense"] as string)
             };
         }
 

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitPackage.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitPackage.cs
@@ -51,10 +51,20 @@ namespace ReactNativePSPDFKit
         /// <returns>The list of native modules.</returns>
         public IReadOnlyList<INativeModule> CreateNativeModules(ReactContext reactContext)
         {
+            object pspdfkitLicense;
+            try
+            {
+                pspdfkitLicense = Application.Current.Resources["PSPDFKitLicense"];
+            }
+            catch (Exception)
+            {
+                throw new Exception("Please ensure you define PSPDFKitLicense. See https://github.com/PSPDFKit/react-native#running-catalog-project-2");
+            }
+
             return new List<INativeModule>
             {
                 new PSPDFKitModule(reactContext, _pspdfkitViewManger),
-                new LibraryModule(reactContext, Application.Current.Resources["PSPDFKitLicense"] as string)
+                new LibraryModule(reactContext, pspdfkitLicense as string)
             };
         }
 

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitViewManager.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitViewManager.cs
@@ -29,10 +29,21 @@ namespace ReactNativePSPDFKit
         private const int COMMAND_SET_TOOLBAR_ITEMS = 7;
         private const int COMMAND_REMOVE_ANNOTATION = 8;
 
-        internal readonly PDFViewPage PdfViewPage = new PDFViewPage();
+        private readonly Uri _cssResource = null;
+        internal PDFViewPage PdfViewPage;
+
+        public PSPDFKitViewManger(Uri cssResource)
+        {
+            _cssResource = cssResource;
+        }
 
         protected override PDFViewPage CreateViewInstance(ThemedReactContext reactContext)
         {
+            PdfViewPage = new PDFViewPage();
+            if(_cssResource != null)
+            {
+                PdfViewPage.Pdfview.Css = _cssResource;
+            }
             return PdfViewPage;
         }
 
@@ -93,28 +104,28 @@ namespace ReactNativePSPDFKit
             switch (commandId)
             {
                 case COMMAND_ENTER_ANNOTATION_CREATION_MODE:
-                    await PdfViewPage.SetInteractionMode(args[0].Value<int>(), InteractionMode.Note);
+                    await view.SetInteractionMode(args[0].Value<int>(), InteractionMode.Note);
                     break;
                 case COMMAND_EXIT_CURRENTLY_ACTIVE_MODE:
-                    await PdfViewPage.SetInteractionMode(args[0].Value<int>(), InteractionMode.None);
+                    await view.SetInteractionMode(args[0].Value<int>(), InteractionMode.None);
                     break;
                 case COMMAND_SAVE_CURRENT_DOCUMENT:
-                    await PdfViewPage.ExportCurrentDocument(args[0].Value<int>());
+                    await view.ExportCurrentDocument(args[0].Value<int>());
                     break;
                 case COMMAND_GET_ANNOTATIONS:
-                    await PdfViewPage.GetAnnotations(args[0].Value<int>(), args[1].Value<int>());
+                    await view.GetAnnotations(args[0].Value<int>(), args[1].Value<int>());
                     break;
                 case COMMAND_ADD_ANNOTATION:
-                    await PdfViewPage.CreateAnnotation(args[0].Value<int>(), args[1].ToString());
+                    await view.CreateAnnotation(args[0].Value<int>(), args[1].ToString());
                     break;
                 case COMMAND_REMOVE_ANNOTATION:
-                    await PdfViewPage.RemoveAnnotation(args[0].Value<int>(), args[1].ToString());
+                    await view.RemoveAnnotation(args[0].Value<int>(), args[1].ToString());
                     break;
                 case COMMAND_GET_TOOLBAR_ITEMS:
-                    PdfViewPage.GetToolbarItems(args[0].Value<int>());
+                    view.GetToolbarItems(args[0].Value<int>());
                     break;
                 case COMMAND_SET_TOOLBAR_ITEMS:
-                    await PdfViewPage.SetToolbarItems(args[0].Value<int>(), args[1].ToString());
+                    await view.SetToolbarItems(args[0].Value<int>(), args[1].ToString());
                     break;
             }
         }


### PR DESCRIPTION
Fixes : https://github.com/PSPDFKit/react-native/issues/212

# Details
There was a lifetime issue when navigating back and forth between views. Now we create a view when react native wants to. The unloading is still handled in UWP.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
