### PR TITLE
Missing version bump from pull request #238

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.24.2",
+  "version": "1.24.3",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",


### PR DESCRIPTION
# Details

- The tag 1.24.3 has to be created after merging this.

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
