### PR TITLE
Fix for PdfView not being rendered

### DIFF
--- a/android/src/main/java/com/pspdfkit/react/ReactPdfViewManager.java
+++ b/android/src/main/java/com/pspdfkit/react/ReactPdfViewManager.java
@@ -16,6 +16,7 @@ import com.pspdfkit.preferences.PSPDFKitPreferences;
 import com.pspdfkit.react.events.PdfViewAnnotationChangedEvent;
 import com.pspdfkit.react.events.PdfViewAnnotationTappedEvent;
 import com.pspdfkit.react.events.PdfViewDataReturnedEvent;
+import com.pspdfkit.react.events.PdfViewDocumentLoadFailedEvent;
 import com.pspdfkit.react.events.PdfViewDocumentSaveFailedEvent;
 import com.pspdfkit.react.events.PdfViewDocumentSavedEvent;
 import com.pspdfkit.react.events.PdfViewStateChangedEvent;
@@ -148,11 +149,13 @@ public class ReactPdfViewManager extends ViewGroupManager<PdfView> {
     @Override
     public Map getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.of(PdfViewStateChangedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onStateChanged"),
-                PdfViewDocumentSavedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onDocumentSaved"),
-                PdfViewAnnotationTappedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onAnnotationTapped"),
-                PdfViewAnnotationChangedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onAnnotationsChanged"),
-                PdfViewDataReturnedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onDataReturned"),
-                PdfViewDocumentSaveFailedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onDocumentSaveFailed"));
+            PdfViewDocumentSavedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onDocumentSaved"),
+            PdfViewAnnotationTappedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onAnnotationTapped"),
+            PdfViewAnnotationChangedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onAnnotationsChanged"),
+            PdfViewDataReturnedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onDataReturned"),
+            PdfViewDocumentSaveFailedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onDocumentSaveFailed"),
+            PdfViewDocumentLoadFailedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onDocumentLoadFailed")
+        );
     }
 
     @Override

--- a/android/src/main/java/com/pspdfkit/react/ReactPdfViewManager.java
+++ b/android/src/main/java/com/pspdfkit/react/ReactPdfViewManager.java
@@ -76,7 +76,7 @@ public class ReactPdfViewManager extends ViewGroupManager<PdfView> {
 
     @Override
     public void onDropViewInstance(PdfView view) {
-        view.removeFragment();
+        view.removeFragment(true);
     }
 
     @Nullable

--- a/android/src/main/java/com/pspdfkit/react/events/PdfViewDocumentLoadFailedEvent.java
+++ b/android/src/main/java/com/pspdfkit/react/events/PdfViewDocumentLoadFailedEvent.java
@@ -1,0 +1,36 @@
+package com.pspdfkit.react.events;
+
+import android.support.annotation.IdRes;
+import android.support.annotation.NonNull;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Event sent by the {@link com.pspdfkit.views.PdfView} when the document load failed.
+ */
+public class PdfViewDocumentLoadFailedEvent extends Event<PdfViewDocumentLoadFailedEvent> {
+
+    public static final String EVENT_NAME = "pdfViewDocumentLoadFailed";
+
+    private final String error;
+
+    public PdfViewDocumentLoadFailedEvent(@IdRes int viewId, @NonNull String error) {
+        super(viewId);
+        this.error = error;
+    }
+
+    @Override
+    public String getEventName() {
+        return EVENT_NAME;
+    }
+
+    @Override
+    public void dispatch(RCTEventEmitter rctEventEmitter) {
+        WritableMap eventData = Arguments.createMap();
+        eventData.putString("error", error);
+        rctEventEmitter.receiveEvent(getViewTag(), getEventName(), eventData);
+    }
+}

--- a/android/src/main/java/com/pspdfkit/views/PdfView.java
+++ b/android/src/main/java/com/pspdfkit/views/PdfView.java
@@ -153,6 +153,9 @@ public class PdfView extends FrameLayout {
                 }
             }
         });
+
+        // Set a default configuration.
+        configuration = new PdfActivityConfiguration.Builder(getContext()).build();
     }
 
     public void inject(FragmentManager fragmentManager, EventDispatcher eventDispatcher) {
@@ -172,7 +175,12 @@ public class PdfView extends FrameLayout {
         setupFragment();
     }
 
-    public void setDocument(String document) {
+    public void setDocument(@Nullable String document) {
+        if (document == null) {
+            removeFragment(false);
+            return;
+        }
+
         if (Uri.parse(document).getScheme() == null) {
             // If there is no scheme it might be a raw path.
             try {
@@ -317,16 +325,19 @@ public class PdfView extends FrameLayout {
         });
     }
 
-    public void removeFragment() {
+    public void removeFragment(boolean makeInactive) {
         PdfFragment pdfFragment = (PdfFragment) fragmentManager.findFragmentByTag(fragmentTag);
         if (pdfFragment != null) {
             fragmentManager.beginTransaction()
                     .remove(pdfFragment)
                     .commitAllowingStateLoss();
         }
-        isActive = false;
+        if (makeInactive) {
+            isActive = false;
+        }
 
         fragment = null;
+        document = null;
         fragmentGetter.onComplete();
         fragmentGetter = BehaviorSubject.create();
         pendingFragmentActions.dispose();
@@ -335,6 +346,7 @@ public class PdfView extends FrameLayout {
             textSelectionPopupToolbar.dismiss();
             textSelectionPopupToolbar = null;
         }
+        pdfThumbnailBar.setVisibility(View.GONE);
     }
 
     void manuallyLayoutChildren() {

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ class PSPDFKitView extends React.Component {
           onStateChanged={this._onStateChanged}
           onDocumentSaved={this._onDocumentSaved}
           onDocumentSaveFailed={this._onDocumentSaveFailed}
+          onDocumentLoadFailed={this._onDocumentLoadFailed}
           onAnnotationTapped={this._onAnnotationTapped}
           onAnnotationsChanged={this._onAnnotationsChanged}
           onDataReturned={this._onDataReturned}
@@ -60,6 +61,12 @@ class PSPDFKitView extends React.Component {
   _onDocumentSaveFailed = event => {
     if (this.props.onDocumentSaveFailed) {
       this.props.onDocumentSaveFailed(event.nativeEvent);
+    }
+  };
+
+  _onDocumentLoadFailed = event => {
+    if (this.props.onDocumentLoadFailed) {
+      this.props.onDocumentLoadFailed(event.nativeEvent);
     }
   };
 

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.h
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) RCTBubblingEventBlock onCloseButtonPressed;
 @property (nonatomic, copy) RCTBubblingEventBlock onDocumentSaved;
 @property (nonatomic, copy) RCTBubblingEventBlock onDocumentSaveFailed;
+@property (nonatomic, copy) RCTBubblingEventBlock onDocumentLoadFailed;
 @property (nonatomic, copy) RCTBubblingEventBlock onAnnotationTapped;
 @property (nonatomic, copy) RCTBubblingEventBlock onAnnotationsChanged;
 @property (nonatomic, copy) RCTBubblingEventBlock onStateChanged;

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -13,7 +13,7 @@
 #import "RCTConvert+PSPDFViewMode.h"
 #import "RCTConvert+UIBarButtonItem.h"
 
-#define VALIDATE_DOCUMENT(document, ...) { if (document.isValid) { NSLog(@"Document is invalid."); if (self.onDocumentLoadFailed) { self.onDocumentLoadFailed(@{@"error": @"Document is invalid."}); } return __VA_ARGS__; }}
+#define VALIDATE_DOCUMENT(document, ...) { if (!document.isValid) { NSLog(@"Document is invalid."); if (self.onDocumentLoadFailed) { self.onDocumentLoadFailed(@{@"error": @"Document is invalid."}); } return __VA_ARGS__; }}
 
 @interface RCTPSPDFKitView ()<PSPDFDocumentDelegate, PSPDFViewControllerDelegate, PSPDFFlexibleToolbarContainerDelegate>
 

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -13,7 +13,7 @@
 #import "RCTConvert+PSPDFViewMode.h"
 #import "RCTConvert+UIBarButtonItem.h"
 
-#define VALIDATE_DOCUMENT(document, ...) { if (!document.isValid) { NSLog(@"Document is invalid."); return __VA_ARGS__; }}
+#define VALIDATE_DOCUMENT(document, ...) { if (document.isValid) { NSLog(@"Document is invalid."); if (self.onDocumentLoadFailed) { self.onDocumentLoadFailed(@{@"error": @"Document is invalid."}); } return __VA_ARGS__; }}
 
 @interface RCTPSPDFKitView ()<PSPDFDocumentDelegate, PSPDFViewControllerDelegate, PSPDFFlexibleToolbarContainerDelegate>
 
@@ -158,6 +158,10 @@
 
 - (void)pdfViewController:(PSPDFViewController *)pdfController willBeginDisplayingPageView:(PSPDFPageView *)pageView forPageAtIndex:(NSInteger)pageIndex {
   [self onStateChangedForPDFViewController:pdfController pageView:pageView pageAtIndex:pageIndex];
+}
+
+- (void)pdfViewController:(PSPDFViewController *)pdfController didChangeDocument:(nullable PSPDFDocument *)document {
+    VALIDATE_DOCUMENT(document)
 }
 
 #pragma mark - PSPDFFlexibleToolbarContainerDelegate

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -93,6 +93,8 @@ RCT_EXPORT_VIEW_PROPERTY(onDocumentSaved, RCTBubblingEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(onDocumentSaveFailed, RCTBubblingEventBlock)
 
+RCT_EXPORT_VIEW_PROPERTY(onDocumentLoadFailed, RCTBubblingEventBlock)
+
 RCT_EXPORT_VIEW_PROPERTY(onAnnotationTapped, RCTBubblingEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(onAnnotationsChanged, RCTBubblingEventBlock)


### PR DESCRIPTION
## Resolves #237 

# Details

This fixes multiple smaller issues:

- The `PSPDFKitView` wouldn't render when no configuration was specified, we now automatically use a default configuration.
- The `PSPDFKitView` was very picky with the file paths it supported, this tries to improve support for paths.
- Setting `document` to `undefined` caused a crash, we now just hide the currently displayed document when `undefined` is set.
- In case there is an error while loading the document the new `onDocumentLoadFailed` will be notified.

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
