### PR TITLE
Add support for old way of accessing the view manager config

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ class PSPDFKitView extends React.Component {
     if (Platform.OS === "android") {
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
-        UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.enterAnnotationCreationMode,
+        this._getViewManagerConfig('RCTPSPDFKitView').Commands.enterAnnotationCreationMode,
         []
       );
     } else if (Platform.OS === "ios") {
@@ -110,7 +110,7 @@ class PSPDFKitView extends React.Component {
     if (Platform.OS === "android") {
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
-        UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.exitCurrentlyActiveMode,
+        this._getViewManagerConfig('RCTPSPDFKitView').Commands.exitCurrentlyActiveMode,
         []
       );
     } else if (Platform.OS === "ios") {
@@ -127,7 +127,7 @@ class PSPDFKitView extends React.Component {
     if (Platform.OS === "android") {
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
-        UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.saveCurrentDocument,
+        this._getViewManagerConfig('RCTPSPDFKitView').Commands.saveCurrentDocument,
         []
       );
     } else if (Platform.OS === "ios") {
@@ -158,7 +158,7 @@ class PSPDFKitView extends React.Component {
 
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
-        UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.getAnnotations,
+        this._getViewManagerConfig('RCTPSPDFKitView').Commands.getAnnotations,
         [requestId, pageIndex, type]
       );
 
@@ -181,7 +181,7 @@ class PSPDFKitView extends React.Component {
     if (Platform.OS === "android") {
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
-        UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.addAnnotation,
+        this._getViewManagerConfig('RCTPSPDFKitView').Commands.addAnnotation,
         [annotation]
       );
     } else if (Platform.OS === "ios") {
@@ -201,7 +201,7 @@ class PSPDFKitView extends React.Component {
     if (Platform.OS === "android") {
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
-        UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.removeAnnotation,
+        this._getViewManagerConfig('RCTPSPDFKitView').Commands.removeAnnotation,
         [annotation]
       );
     } else if (Platform.OS === "ios") {
@@ -229,7 +229,7 @@ class PSPDFKitView extends React.Component {
 
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
-        UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.getAllUnsavedAnnotations,
+        this._getViewManagerConfig('RCTPSPDFKitView').Commands.getAllUnsavedAnnotations,
         [requestId]
       );
 
@@ -250,7 +250,7 @@ class PSPDFKitView extends React.Component {
     if (Platform.OS === "android") {
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
-        UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.addAnnotations,
+        this._getViewManagerConfig('RCTPSPDFKitView').Commands.addAnnotations,
         [annotations]
       );
     } else if (Platform.OS === "ios") {
@@ -281,7 +281,7 @@ class PSPDFKitView extends React.Component {
 
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
-        UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.getFormFieldValue,
+        this._getViewManagerConfig('RCTPSPDFKitView').Commands.getFormFieldValue,
         [requestId, fullyQualifiedName]
       );
 
@@ -304,7 +304,7 @@ class PSPDFKitView extends React.Component {
     if (Platform.OS === "android") {
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
-        UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.setFormFieldValue,
+        this._getViewManagerConfig('RCTPSPDFKitView').Commands.setFormFieldValue,
         [fullyQualifiedName, value]
       );
     } else if (Platform.OS === "ios") {
@@ -387,6 +387,15 @@ class PSPDFKitView extends React.Component {
         viewMode,
         findNodeHandle(this.refs.pdfView)
       );
+    }
+  };
+
+  _getViewManagerConfig = viewManagerName => {
+    const version = NativeModules.PlatformConstants.reactNativeVersion.minor
+    if (version >= 58) {
+      return UIManager.getViewManagerConfig(viewManagerName);
+    } else {
+      return UIManager[viewManagerName];
     }
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.24.3",
+  "version": "1.24.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.24.3",
+  "version": "1.24.4",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.24.3",
+  "version": "1.24.4",
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start"


### PR DESCRIPTION
## Resolves #247 

# Details

When updating to react-native `0.59.9` we updated our way of accessing the view manager configs. This does not work when running under react-native `0.57.2` which is the lowest version specified in our `package.json`. This adds a method to use the appropriate way of accesing the view manager config depending on the current react-native version.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
