### PR TITLE
downgrade netwonsoft dependency to avoid a memory leak in v12

### DIFF
--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/ReactNativePSPDFKit.csproj
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/ReactNativePSPDFKit.csproj
@@ -131,7 +131,7 @@
       <Version>2.0.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.2</Version>
+      <Version>11.0.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
#Details

There seems to be a memory leak in Newtonsoft 12.0.x which caused #239. Downgrading Newtonsonft to the last working version fixes the immediate issue until there is a new release of Newtonsoft without memory leaks.

There is a closed isue about a memory leak in v12: https://github.com/JamesNK/Newtonsoft.Json/issues/1991

However I am not sure whether this was the leak we were hitting ...

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
