### PR TITLE
Add `toolbarTitle` Javascript API to override the iOS toolbar title

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,8 @@ class PSPDFKitView extends React.Component {
     if (Platform.OS === "android") {
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
-        this._getViewManagerConfig('RCTPSPDFKitView').Commands.enterAnnotationCreationMode,
+        this._getViewManagerConfig("RCTPSPDFKitView").Commands
+          .enterAnnotationCreationMode,
         []
       );
     } else if (Platform.OS === "ios") {
@@ -117,7 +118,8 @@ class PSPDFKitView extends React.Component {
     if (Platform.OS === "android") {
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
-        this._getViewManagerConfig('RCTPSPDFKitView').Commands.exitCurrentlyActiveMode,
+        this._getViewManagerConfig("RCTPSPDFKitView").Commands
+          .exitCurrentlyActiveMode,
         []
       );
     } else if (Platform.OS === "ios") {
@@ -134,7 +136,8 @@ class PSPDFKitView extends React.Component {
     if (Platform.OS === "android") {
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
-        this._getViewManagerConfig('RCTPSPDFKitView').Commands.saveCurrentDocument,
+        this._getViewManagerConfig("RCTPSPDFKitView").Commands
+          .saveCurrentDocument,
         []
       );
     } else if (Platform.OS === "ios") {
@@ -165,7 +168,7 @@ class PSPDFKitView extends React.Component {
 
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
-        this._getViewManagerConfig('RCTPSPDFKitView').Commands.getAnnotations,
+        this._getViewManagerConfig("RCTPSPDFKitView").Commands.getAnnotations,
         [requestId, pageIndex, type]
       );
 
@@ -188,7 +191,7 @@ class PSPDFKitView extends React.Component {
     if (Platform.OS === "android") {
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
-        this._getViewManagerConfig('RCTPSPDFKitView').Commands.addAnnotation,
+        this._getViewManagerConfig("RCTPSPDFKitView").Commands.addAnnotation,
         [annotation]
       );
     } else if (Platform.OS === "ios") {
@@ -208,7 +211,7 @@ class PSPDFKitView extends React.Component {
     if (Platform.OS === "android") {
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
-        this._getViewManagerConfig('RCTPSPDFKitView').Commands.removeAnnotation,
+        this._getViewManagerConfig("RCTPSPDFKitView").Commands.removeAnnotation,
         [annotation]
       );
     } else if (Platform.OS === "ios") {
@@ -236,7 +239,8 @@ class PSPDFKitView extends React.Component {
 
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
-        this._getViewManagerConfig('RCTPSPDFKitView').Commands.getAllUnsavedAnnotations,
+        this._getViewManagerConfig("RCTPSPDFKitView").Commands
+          .getAllUnsavedAnnotations,
         [requestId]
       );
 
@@ -257,7 +261,7 @@ class PSPDFKitView extends React.Component {
     if (Platform.OS === "android") {
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
-        this._getViewManagerConfig('RCTPSPDFKitView').Commands.addAnnotations,
+        this._getViewManagerConfig("RCTPSPDFKitView").Commands.addAnnotations,
         [annotations]
       );
     } else if (Platform.OS === "ios") {
@@ -288,7 +292,8 @@ class PSPDFKitView extends React.Component {
 
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
-        this._getViewManagerConfig('RCTPSPDFKitView').Commands.getFormFieldValue,
+        this._getViewManagerConfig("RCTPSPDFKitView").Commands
+          .getFormFieldValue,
         [requestId, fullyQualifiedName]
       );
 
@@ -311,7 +316,8 @@ class PSPDFKitView extends React.Component {
     if (Platform.OS === "android") {
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
-        this._getViewManagerConfig('RCTPSPDFKitView').Commands.setFormFieldValue,
+        this._getViewManagerConfig("RCTPSPDFKitView").Commands
+          .setFormFieldValue,
         [fullyQualifiedName, value]
       );
     } else if (Platform.OS === "ios") {
@@ -398,7 +404,7 @@ class PSPDFKitView extends React.Component {
   };
 
   _getViewManagerConfig = viewManagerName => {
-    const version = NativeModules.PlatformConstants.reactNativeVersion.minor
+    const version = NativeModules.PlatformConstants.reactNativeVersion.minor;
     if (version >= 58) {
       return UIManager.getViewManagerConfig(viewManagerName);
     } else {
@@ -531,7 +537,15 @@ PSPDFKitView.propTypes = {
    *
    * @platform ios
    */
-  rightBarButtonItems: PropTypes.array
+  rightBarButtonItems: PropTypes.array,
+  /**
+   * toolbarTitle: Can be used to specfiy a custom toolbar title on iOS by setting the `title` property of the `PSPDFViewController`.
+   * Note: You need to set `showDocumentLabel`, `useParentNavigationBar`, and `allowToolbarTitleChange` to false in your Configuration before setting the custom title.
+   * See `ConfiguredPDFViewComponent` in https://github.com/PSPDFKit/react-native/blob/master/samples/Catalog/Catalog.ios.js
+   *
+   * @platform ios
+   */
+  toolbarTitle: PropTypes.string
 };
 
 if (Platform.OS === "ios" || Platform.OS === "android") {

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -73,6 +73,12 @@ RCT_CUSTOM_VIEW_PROPERTY(rightBarButtonItems, NSArray<UIBarButtonItem *>, RCTPSP
   }
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(toolbarTitle, NSString, RCTPSPDFKitView) {
+  if (json) {
+    view.pdfController.title = json;
+  }
+}
+
 RCT_EXPORT_VIEW_PROPERTY(hideNavigationBar, BOOL)
 
 RCT_EXPORT_VIEW_PROPERTY(disableDefaultActionForTappedAnnotations, BOOL)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.24.5",
+  "version": "1.24.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.24.5",
+  "version": "1.24.6",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/Catalog.ios.js
+++ b/samples/Catalog/Catalog.ios.js
@@ -251,8 +251,11 @@ class ConfiguredPDFViewComponent extends Component {
           configuration={{
             backgroundColor: processColor("lightgrey"),
             showThumbnailBar: "scrubberBar",
-            showDocumentLabel: true
+            showDocumentLabel: false,
+            useParentNavigationBar: false,
+            allowToolbarTitleChange: false
           }}
+          toolbarTitle={"Custom Title"}
           style={{ flex: 1, color: pspdfkitColor }}
         />
       </View>

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.24.5",
+  "version": "1.24.6",
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start"


### PR DESCRIPTION
Solves #253 

---

# Details

Adds `toolbarTitle` Javascript API to override the iOS toolbar title. See `ConfiguredPDFViewComponent` example from `Catalog.ios.js`.

<img width="844" alt="Screen Shot 2019-07-15 at 11 38 40 AM" src="https://user-images.githubusercontent.com/7443038/61228986-53860080-a6f5-11e9-9f1c-29a9aa855121.png">

**Note:** This requires to set `showDocumentLabel`, `useParentNavigationBar`, and `allowToolbarTitleChange` to false in your Configuration before setting the custom title. 

## Usage:

```js
<PSPDFKitView
  document={"PDFs/Annual Report.pdf"}
  configuration={{
    showDocumentLabel: false,
    useParentNavigationBar: false,
    allowToolbarTitleChange: false
  }}
  toolbarTitle={"Custom Title"}
/>
```

# Acceptance Criteria

- [x] This API is iOS-only. It doesn't impact Android.
- [x] This API is iOS-only. It doesn't impact UWP.
- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [x] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
