### PR TITLE
Android improvements

### DIFF
--- a/android/src/main/java/com/pspdfkit/react/ReactPdfViewManager.java
+++ b/android/src/main/java/com/pspdfkit/react/ReactPdfViewManager.java
@@ -192,8 +192,9 @@ public class ReactPdfViewManager extends ViewGroupManager<PdfView> {
                 }
                 break;
             case COMMAND_REMOVE_ANNOTATION:
-                if (args != null) {
-                    annotationDisposables.add(root.removeAnnotation(args.getMap(0)));
+                if (args != null && args.size() == 2) {
+                    final int requestId = args.getInt(0);
+                    annotationDisposables.add(root.removeAnnotation(requestId, args.getMap(1)));
                 }
                 break;
             case COMMAND_GET_ALL_UNSAVED_ANNOTATIONS:

--- a/android/src/main/java/com/pspdfkit/react/ReactPdfViewManager.java
+++ b/android/src/main/java/com/pspdfkit/react/ReactPdfViewManager.java
@@ -186,8 +186,9 @@ public class ReactPdfViewManager extends ViewGroupManager<PdfView> {
                 }
                 break;
             case COMMAND_ADD_ANNOTATION:
-                if (args != null) {
-                    annotationDisposables.add(root.addAnnotation(args.getMap(0)));
+                if (args != null && args.size() == 2) {
+                    final int requestId = args.getInt(0);
+                    annotationDisposables.add(root.addAnnotation(requestId, args.getMap(1)));
                 }
                 break;
             case COMMAND_REMOVE_ANNOTATION:

--- a/android/src/main/java/com/pspdfkit/react/ReactPdfViewManager.java
+++ b/android/src/main/java/com/pspdfkit/react/ReactPdfViewManager.java
@@ -211,8 +211,9 @@ public class ReactPdfViewManager extends ViewGroupManager<PdfView> {
                 }
                 break;
             case COMMAND_ADD_ANNOTATIONS:
-                if (args != null && args.size() == 1) {
-                    annotationDisposables.add(root.addAnnotations(args.getMap(0)));
+                if (args != null && args.size() == 2) {
+                    final int requestId = args.getInt(0);
+                    annotationDisposables.add(root.addAnnotations(requestId, args.getMap(1)));
                 }
                 break;
             case COMMAND_GET_FORM_FIELD_VALUE:

--- a/android/src/main/java/com/pspdfkit/react/events/PdfViewDataReturnedEvent.java
+++ b/android/src/main/java/com/pspdfkit/react/events/PdfViewDataReturnedEvent.java
@@ -47,6 +47,16 @@ public class PdfViewDataReturnedEvent extends Event<PdfViewDataReturnedEvent> {
         payload = Arguments.makeNativeMap(map);
     }
 
+    public PdfViewDataReturnedEvent(@IdRes int viewId, int requestId, boolean result) {
+        super(viewId);
+        this.requestId = requestId;
+        Map<String, Object> map = new HashMap<>();
+        map.put("requestId", requestId);
+        map.put("result", result);
+
+        payload = Arguments.makeNativeMap(map);
+    }
+
     public PdfViewDataReturnedEvent(@IdRes int viewId, int requestId, @NonNull JSONObject jsonObject) {
         super(viewId);
         this.requestId = requestId;

--- a/index.js
+++ b/index.js
@@ -256,14 +256,27 @@ class PSPDFKitView extends React.Component {
    * Applies the passed in document instant json.
    *
    * @param annotations The document instant json to apply.
+   * 
+   * Returns a promise resolving a dictionary with the following structure:
+   * {'annotations' : 'created'}.
    */
   addAnnotations = function(annotations) {
     if (Platform.OS === "android") {
+      let requestId = this._nextRequestId++;
+      let requestMap = this._requestMap;
+
+      // We create a promise here that will be resolved once onDataReturned is called.
+      let promise = new Promise(function(resolve, reject) {
+        requestMap[requestId] = { resolve: resolve, reject: reject };
+      });
+
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
         this._getViewManagerConfig("RCTPSPDFKitView").Commands.addAnnotations,
-        [annotations]
+        [requestId, annotations]
       );
+
+      return promise
     } else if (Platform.OS === "ios") {
       return NativeModules.PSPDFKitViewManager.addAnnotations(
         annotations,

--- a/index.js
+++ b/index.js
@@ -186,14 +186,27 @@ class PSPDFKitView extends React.Component {
    * Adds a new annotation to the current document.
    *
    * @param annotation InstantJson of the annotation to add.
+   * 
+   * Returns a promise resolving a dictionary with the following structure:
+   * {'annotation' : instantJson}.
    */
   addAnnotation = function(annotation) {
     if (Platform.OS === "android") {
+      let requestId = this._nextRequestId++;
+      let requestMap = this._requestMap;
+
+      // We create a promise here that will be resolved once onDataReturned is called.
+      let promise = new Promise(function(resolve, reject) {
+        requestMap[requestId] = { resolve: resolve, reject: reject };
+      });
+
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
         this._getViewManagerConfig("RCTPSPDFKitView").Commands.addAnnotation,
-        [annotation]
+        [requestId, annotation]
       );
+
+      return promise
     } else if (Platform.OS === "ios") {
       return NativeModules.PSPDFKitViewManager.addAnnotation(
         annotation,

--- a/index.js
+++ b/index.js
@@ -153,7 +153,8 @@ class PSPDFKitView extends React.Component {
    * @param pageIndex The page to get the annotations for.
    * @param type The type of annotations to get (See here for types https://pspdfkit.com/guides/server/current/api/json-format/) or null to get all annotations.
    *
-   * Returns a promise resolving to true if the annotation was added.
+   * Returns a promise resolving an array with the following structure:
+   * {'annotations' : [instantJson]}
    */
   getAnnotations = function(pageIndex, type) {
     if (Platform.OS === "android") {
@@ -217,7 +218,7 @@ class PSPDFKitView extends React.Component {
    * Removes an existing annotation from the current document.
    *
    * @param annotation InstantJson of the annotation to remove.
-   * 
+   *
    * Returns a promise resolving to true if the annotation was removed and to false if the annotation couldn't be found.
    */
   removeAnnotation = function(annotation) {
@@ -280,8 +281,7 @@ class PSPDFKitView extends React.Component {
    *
    * @param annotations The document instant json to apply.
    *
-   * Returns a promise resolving a dictionary with the following structure:
-   * {'annotations' : 'created'}.
+   * Returns a promise resolving to true if the annotation was added.
    */
   addAnnotations = function(annotations) {
     if (Platform.OS === "android") {

--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ class PSPDFKitView extends React.Component {
    *
    * @param annotation InstantJson of the annotation to add.
    *
-   * Returns a promise resolving to true if the annotation was added.
+   * Returns a promise resolving to true if the annotation was added. Otherwise, returns false if an error has occurred.
    */
   addAnnotation = function(annotation) {
     if (Platform.OS === "android") {
@@ -219,7 +219,7 @@ class PSPDFKitView extends React.Component {
    *
    * @param annotation InstantJson of the annotation to remove.
    *
-   * Returns a promise resolving to true if the annotation was removed and to false if the annotation couldn't be found.
+   * Returns a promise resolving to true if the annotation was removed. Otherwise, returns false if the annotation couldn't be found.
    */
   removeAnnotation = function(annotation) {
     if (Platform.OS === "android") {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.24.8",
+  "version": "1.24.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.24.8",
+  "version": "1.24.9",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/Catalog.android.js
+++ b/samples/Catalog/Catalog.android.js
@@ -632,7 +632,12 @@ class PdfViewInstantJsonScreen extends Component<{}> {
                   type: "pspdfkit/ink",
                   updatedAt: "2018-07-03T13:53:03Z",
                   v: 1
-                });
+                }).then(result => {
+                  alert(JSON.stringify(result))
+                })
+                .catch(ex => {
+                  alert(JSON.stringify(ex))
+                })
               }}
               title="Add annotation"
             />

--- a/samples/Catalog/Catalog.android.js
+++ b/samples/Catalog/Catalog.android.js
@@ -22,7 +22,7 @@ import {
 } from "react-native";
 import { StackNavigator, NavigationEvents } from "react-navigation";
 
-import QRCodeScanner from 'react-native-qrcode-scanner';
+import QRCodeScanner from "react-native-qrcode-scanner";
 
 import PSPDFKitView from "react-native-pspdfkit";
 
@@ -69,8 +69,8 @@ const examples = [
     name: "Open local document",
     description: "Open document from external storage directory.",
     action: () => {
-      requestExternalStoragePermission(function () {
-        extractFromAssetsIfMissing("Annual Report.pdf", function () {
+      requestExternalStoragePermission(function() {
+        extractFromAssetsIfMissing("Annual Report.pdf", function() {
           PSPDFKit.present(DOCUMENT, {});
         });
       });
@@ -81,8 +81,8 @@ const examples = [
     name: "Open local image document",
     description: "Open image image document from external storage directory.",
     action: () => {
-      requestExternalStoragePermission(function () {
-        extractFromAssetsIfMissing("android.png", function () {
+      requestExternalStoragePermission(function() {
+        extractFromAssetsIfMissing("android.png", function() {
           PSPDFKit.presentImage(IMAGE_DOCUMENT, CONFIGURATION_IMAGE_DOCUMENT);
         });
       });
@@ -94,7 +94,7 @@ const examples = [
     description:
       "You can configure the builder with dictionary representation of the PSPDFConfiguration object.",
     action: () => {
-      requestExternalStoragePermission(function () {
+      requestExternalStoragePermission(function() {
         PSPDFKit.present(DOCUMENT, CONFIGURATION);
       });
     }
@@ -171,7 +171,7 @@ function extractFromAssetsIfMissing(assetFile, callback) {
       } else {
         console.log(
           assetFile +
-          " does not exist, extracting it from assets folder to the external storage directory."
+            " does not exist, extracting it from assets folder to the external storage directory."
         );
         RNFS.existsAssets(assetFile)
           .then(exist => {
@@ -190,7 +190,7 @@ function extractFromAssetsIfMissing(assetFile, callback) {
               // File does not exist, it should never happen.
               throw new Error(
                 assetFile +
-                " couldn't be extracted as it was not found in the project assets folder."
+                  " couldn't be extracted as it was not found in the project assets folder."
               );
             }
           })
@@ -337,7 +337,12 @@ class PdfViewScreen extends Component<{}> {
           }}
           pageIndex={this.state.currentPageIndex}
           fragmentTag="PDF1"
-          menuItemGrouping={['freetext', {key: 'markup', items: ['highlight', "underline"]}, 'ink', 'image']}
+          menuItemGrouping={[
+            "freetext",
+            { key: "markup", items: ["highlight", "underline"] },
+            "ink",
+            "image"
+          ]}
           onStateChanged={event => {
             this.setState({
               currentPageIndex: event.currentPageIndex,
@@ -600,44 +605,51 @@ class PdfViewInstantJsonScreen extends Component<{}> {
             <Button
               onPress={() => {
                 // This adds a new ink annotation to the first page.
-                this.refs.pdfView.addAnnotation({
-                  bbox: [
-                    89.58633422851562,
-                    98.5791015625,
-                    143.12948608398438,
-                    207.1583251953125
-                  ],
-                  blendMode: "normal",
-                  createdAt: "2018-07-03T13:53:03Z",
-                  isDrawnNaturally: false,
-                  lineWidth: 5,
-                  lines: {
-                    intensities: [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5]],
-                    points: [
-                      [
-                        [92.08633422851562, 101.07916259765625],
-                        [92.08633422851562, 202.15826416015625],
-                        [138.12950134277344, 303.2374267578125]
-                      ],
-                      [
-                        [184.17266845703125, 101.07916259765625],
-                        [184.17266845703125, 202.15826416015625],
-                        [230.2158203125, 303.2374267578125]
+                this.refs.pdfView
+                  .addAnnotation({
+                    bbox: [
+                      89.58633422851562,
+                      98.5791015625,
+                      143.12948608398438,
+                      207.1583251953125
+                    ],
+                    blendMode: "normal",
+                    createdAt: "2018-07-03T13:53:03Z",
+                    isDrawnNaturally: false,
+                    lineWidth: 5,
+                    name: 'my annotation',
+                    lines: {
+                      intensities: [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5]],
+                      points: [
+                        [
+                          [92.08633422851562, 101.07916259765625],
+                          [92.08633422851562, 202.15826416015625],
+                          [138.12950134277344, 303.2374267578125]
+                        ],
+                        [
+                          [184.17266845703125, 101.07916259765625],
+                          [184.17266845703125, 202.15826416015625],
+                          [230.2158203125, 303.2374267578125]
+                        ]
                       ]
-                    ]
-                  },
-                  opacity: 1,
-                  pageIndex: 0,
-                  strokeColor: "#AA47BE",
-                  type: "pspdfkit/ink",
-                  updatedAt: "2018-07-03T13:53:03Z",
-                  v: 1
-                }).then(result => {
-                  alert(JSON.stringify(result))
-                })
-                .catch(ex => {
-                  alert(JSON.stringify(ex))
-                })
+                    },
+                    opacity: 1,
+                    pageIndex: 0,
+                    strokeColor: "#AA47BE",
+                    type: "pspdfkit/ink",
+                    updatedAt: "2018-07-03T13:53:03Z",
+                    v: 1
+                  })
+                  .then(result => {
+                    if (result) {
+                      alert("Annotation was added.");
+                    } else {
+                      alert("Annotation was not added.");
+                    }
+                  })
+                  .catch(error => {
+                    alert(JSON.stringify(error));
+                  });
               }}
               title="Add annotation"
             />
@@ -647,10 +659,21 @@ class PdfViewInstantJsonScreen extends Component<{}> {
               onPress={() => {
                 // This removes the first annotation on the first page.
                 this.refs.pdfView.getAnnotations(0, null).then(results => {
-                  const annotations = results.annotations
+                  const annotations = results.annotations;
                   if (annotations.length >= 1) {
                     const annotation = annotations[0];
-                    this.refs.pdfView.removeAnnotation(annotation);
+                    this.refs.pdfView
+                      .removeAnnotation(annotation)
+                      .then(result => {
+                        if (result) {
+                          alert("Annotation was removed.");
+                        } else {
+                          alert("Annotation was not removed.");
+                        }
+                      })
+                      .catch(error => {
+                        alert(JSON.stringify(error));
+                      });
                   }
                 });
               }}
@@ -743,23 +766,24 @@ class InstantExampleScreen extends Component<{}> {
   };
 
   onSuccess = qrData => {
-    const documentInfoUrl = qrData.data
+    const documentInfoUrl = qrData.data;
     fetch(documentInfoUrl)
       .then(response => {
         if (response.ok) {
           return response.json();
         }
-        throw new Error('Error message.');
-      }).then(data => {
-        this.props.navigation.popToTop();
-        PSPDFKit.presentInstant(data.serverUrl, data.jwt, {})
-      }).catch(e => {
-        console.log("failed to load ", url, e.message);
+        throw new Error("Error message.");
       })
-  }
+      .then(data => {
+        this.props.navigation.popToTop();
+        PSPDFKit.presentInstant(data.serverUrl, data.jwt, {});
+      })
+      .catch(e => {
+        console.log("failed to load ", url, e.message);
+      });
+  };
 
   render() {
-
     return (
       <View style={{ flex: 1 }}>
         {this.props.navigation.isFocused && (
@@ -767,8 +791,10 @@ class InstantExampleScreen extends Component<{}> {
             onRead={this.onSuccess}
             topContent={
               <Text style={styles.centerText}>
-                Scan the QR code from <Text style={styles.textBold}>pspdfkit.com/instant/demo</Text> to connect to the document shown in your browser.
-            </Text>
+                Scan the QR code from{" "}
+                <Text style={styles.textBold}>pspdfkit.com/instant/demo</Text>{" "}
+                to connect to the document shown in your browser.
+              </Text>
             }
           />
         )}
@@ -851,10 +877,10 @@ var styles = StyleSheet.create({
     flex: 1,
     fontSize: 18,
     padding: 32,
-    color: '#777',
+    color: "#777"
   },
   textBold: {
-    fontWeight: '500',
-    color: '#000',
+    fontWeight: "500",
+    color: "#000"
   }
 });

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.24.8",
+  "version": "1.24.9",
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start"


### PR DESCRIPTION
## Resolves #250 - Resolves #251 - Resolves #252 

# Details

- Both `addAnnotation` and `addAnnotations` now returns a `Promise` on Android allowing you to handle errors thrown by these methods.
- Updating the `configuration` prop will now automatically recreate the `PdfFragment` with the new configuration.

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
