### PR TITLE
Implement `getAllAnnotations()`

### DIFF
--- a/android/src/main/java/com/pspdfkit/react/ReactPdfViewManager.java
+++ b/android/src/main/java/com/pspdfkit/react/ReactPdfViewManager.java
@@ -1,6 +1,7 @@
 package com.pspdfkit.react;
 
 import android.app.Activity;
+
 import androidx.annotation.NonNull;
 import androidx.fragment.app.FragmentActivity;
 
@@ -51,6 +52,7 @@ public class ReactPdfViewManager extends ViewGroupManager<PdfView> {
     public static final int COMMAND_GET_FORM_FIELD_VALUE = 8;
     public static final int COMMAND_SET_FORM_FIELD_VALUE = 9;
     public static final int COMMAND_REMOVE_ANNOTATION = 10;
+    public static final int COMMAND_GET_ALL_ANNOTATIONS = 11;
 
     private CompositeDisposable annotationDisposables = new CompositeDisposable();
 
@@ -100,6 +102,7 @@ public class ReactPdfViewManager extends ViewGroupManager<PdfView> {
         commandMap.put("getFormFieldValue", COMMAND_GET_FORM_FIELD_VALUE);
         commandMap.put("setFormFieldValue", COMMAND_SET_FORM_FIELD_VALUE);
         commandMap.put("removeAnnotation", COMMAND_REMOVE_ANNOTATION);
+        commandMap.put("getAllAnnotations", COMMAND_GET_ALL_ANNOTATIONS);
         return commandMap;
     }
 
@@ -183,6 +186,19 @@ public class ReactPdfViewManager extends ViewGroupManager<PdfView> {
                                 }
                             });
                     annotationDisposables.add(annotationDisposable);
+                }
+                break;
+            case COMMAND_GET_ALL_ANNOTATIONS:
+                if (args != null && args.size() == 2) {
+                    final int requestId = args.getInt(0);
+                    annotationDisposables.add(root.getAllAnnotations(args.getString(1))
+                        .subscribeOn(Schedulers.io())
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .subscribe(annotations -> {
+                            root.getEventDispatcher().dispatchEvent(new PdfViewDataReturnedEvent(root.getId(), requestId, annotations));
+                        }, throwable -> {
+                            root.getEventDispatcher().dispatchEvent(new PdfViewDataReturnedEvent(root.getId(), requestId, throwable));
+                        }));
                 }
                 break;
             case COMMAND_ADD_ANNOTATION:

--- a/android/src/main/java/com/pspdfkit/views/PdfView.java
+++ b/android/src/main/java/com/pspdfkit/views/PdfView.java
@@ -2,16 +2,16 @@ package com.pspdfkit.views;
 
 import android.content.Context;
 import android.net.Uri;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.FragmentManager;
-
 import android.util.AttributeSet;
 import android.util.Pair;
 import android.view.Choreographer;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.FrameLayout;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.FragmentManager;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.events.EventDispatcher;
@@ -30,7 +30,6 @@ import com.pspdfkit.forms.FormElement;
 import com.pspdfkit.forms.TextFormElement;
 import com.pspdfkit.listeners.OnPreparePopupToolbarListener;
 import com.pspdfkit.listeners.SimpleDocumentListener;
-import com.pspdfkit.react.R;
 import com.pspdfkit.react.events.PdfViewDataReturnedEvent;
 import com.pspdfkit.react.events.PdfViewDocumentLoadFailedEvent;
 import com.pspdfkit.react.events.PdfViewDocumentSaveFailedEvent;
@@ -449,9 +448,15 @@ public class PdfView extends FrameLayout {
         }).flatMap(new Function<PdfDocument, ObservableSource<Annotation>>() {
             @Override
             public ObservableSource<Annotation> apply(PdfDocument pdfDocument) {
-                return pdfDocument.getAnnotationProvider().getAllAnnotationsOfType(getTypeFromString(type), pageIndex, 1);
+                return pdfDocument.getAnnotationProvider().getAllAnnotationsOfTypeAsync(getTypeFromString(type), pageIndex, 1);
             }
         }).toList();
+    }
+
+    public Single<List<Annotation>> getAllAnnotations(@Nullable final String type) {
+        return fragmentGetter.take(1).map(PdfFragment::getDocument)
+            .flatMap(pdfDocument -> pdfDocument.getAnnotationProvider().getAllAnnotationsOfTypeAsync(getTypeFromString(type)))
+            .toList();
     }
 
     private EnumSet<AnnotationType> getTypeFromString(@Nullable String type) {

--- a/index.js
+++ b/index.js
@@ -277,6 +277,25 @@ class PSPDFKitView extends React.Component {
   };
 
   /**
+   * Gets all annotations of the given type.
+   *
+   * @param type The type of annotations to get (See here for types https://pspdfkit.com/guides/server/current/api/json-format/) or null to get all annotations.
+   *
+   * Returns a promise resolving an array with the following structure:
+   * {'annotations' : [instantJson]}
+   */
+  getAllAnnotations = function(type) {
+    if (Platform.OS === "android") {
+      //TODO: Implement Android here.
+    } else if (Platform.OS === "ios") {
+      return NativeModules.PSPDFKitViewManager.getAllAnnotations(
+        type,
+        findNodeHandle(this.refs.pdfView)
+      );
+    }
+  };
+
+  /**
    * Applies the passed in document instant json.
    *
    * @param annotations The document instant json to apply.

--- a/index.js
+++ b/index.js
@@ -286,7 +286,22 @@ class PSPDFKitView extends React.Component {
    */
   getAllAnnotations = function(type) {
     if (Platform.OS === "android") {
-      //TODO: Implement Android here.
+      let requestId = this._nextRequestId++;
+      let requestMap = this._requestMap;
+
+      // We create a promise here that will be resolved once onDataReturned is called.
+      let promise = new Promise(function(resolve, reject) {
+        requestMap[requestId] = { resolve: resolve, reject: reject };
+      });
+
+      UIManager.dispatchViewManagerCommand(
+        findNodeHandle(this.refs.pdfView),
+        this._getViewManagerConfig("RCTPSPDFKitView").Commands
+          .getAllAnnotations,
+        [requestId, type]
+      );
+
+      return promise;
     } else if (Platform.OS === "ios") {
       return NativeModules.PSPDFKitViewManager.getAllAnnotations(
         type,

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.h
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.h
@@ -43,6 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)addAnnotation:(id)jsonAnnotation error:(NSError *_Nullable *)error;
 - (BOOL)removeAnnotationWithUUID:(NSString *)annotationUUID;
 - (NSDictionary<NSString *, NSArray<NSDictionary *> *> *)getAllUnsavedAnnotationsWithError:(NSError *_Nullable *)error;
+- (NSDictionary<NSString *, NSArray<NSDictionary *> *> *)getAllAnnotations:(PSPDFAnnotationType)type error:(NSError *_Nullable *)error;
 - (BOOL)addAnnotations:(NSString *)jsonAnnotations error:(NSError *_Nullable *)error;
 
 /// Forms

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -247,6 +247,15 @@
   return annotationsJSON;
 }
 
+- (NSDictionary<NSString *, NSArray<NSDictionary *> *> *)getAllAnnotations:(PSPDFAnnotationType)type error:(NSError *_Nullable *)error {
+  PSPDFDocument *document = self.pdfController.document;
+  VALIDATE_DOCUMENT(document, nil)
+
+  NSArray<PSPDFAnnotation *> *annotations = [[document allAnnotationsOfType:type].allValues valueForKeyPath:@"@unionOfArrays.self"];
+  NSArray <NSDictionary *> *annotationsJSON = [RCTConvert instantJSONFromAnnotations:annotations error:error];
+  return @{@"annotations" : annotationsJSON};
+}
+
 - (BOOL)addAnnotations:(id)jsonAnnotations error:(NSError *_Nullable *)error {
   NSData *data;
   if ([jsonAnnotations isKindOfClass:NSString.class]) {

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -195,6 +195,19 @@ RCT_EXPORT_METHOD(getAllUnsavedAnnotations:(nonnull NSNumber *)reactTag resolver
   });
 }
 
+RCT_EXPORT_METHOD(getAllAnnotations:(NSString *)type reactTag:(nonnull NSNumber *)reactTag resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];
+    NSError *error;
+    NSDictionary *annotations = [component getAllAnnotations:[RCTConvert annotationTypeFromInstantJSONType:type] error:&error];
+    if (annotations) {
+      resolve(annotations);
+    } else {
+      reject(@"error", @"Failed to get all annotations.", error);
+    }
+  });
+}
+
 RCT_EXPORT_METHOD(addAnnotations:(id)jsonAnnotations reactTag:(nonnull NSNumber *)reactTag resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   dispatch_async(dispatch_get_main_queue(), ^{
     RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/Catalog.android.js
+++ b/samples/Catalog/Catalog.android.js
@@ -588,8 +588,8 @@ class PdfViewInstantJsonScreen extends Component<{}> {
           <View>
             <Button
               onPress={() => {
-                // This gets all annotations on the first page.
-                this.refs.pdfView.getAnnotations(0, null).then(annotations => {
+                // This gets all annotations in the document.
+                this.refs.pdfView.getAllAnnotations().then(annotations => {
                   alert(JSON.stringify(annotations));
                 });
               }}

--- a/samples/Catalog/Catalog.ios.js
+++ b/samples/Catalog/Catalog.ios.js
@@ -783,6 +783,26 @@ class ProgrammaticAnnotations extends Component {
               title="getAllUnsavedAnnotations"
             />
           </View>
+          <View>
+            <Button
+              onPress={async () => {
+                // Get all annotations annotations from the document.
+                await this.refs.pdfView
+                  .getAllAnnotations()
+                  .then(result => {
+                    if (result) {
+                      alert(JSON.stringify(result));
+                    } else {
+                      alert("Failed to get all annotations.");
+                    }
+                  })
+                  .catch(error => {
+                    alert(JSON.stringify(error));
+                  });
+              }}
+              title="getAllAnnotations"
+            />
+          </View>
         </View>
       </View>
     );

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "scripts": {
     "start": "react-native start",


### PR DESCRIPTION
# Details

The iOS and Android implementation for #167 

![recording](https://user-images.githubusercontent.com/7443038/62548963-a73bc380-b835-11e9-9014-9bc378d087b0.gif)

# Acceptance Criteria

- [x] Implement `getAllAnnotations()` on iOS.
- [x] Implement `getAllAnnotations()` on Android.
- [x] Remove the `ios` and `android` tags from #167 and leave the issue opened for UWP.
- [x] This change does not impact UWP.
- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
