### PR TITLE
Remove demo artifacts from build script

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 *   Contains gradle configuration constants
 */
 ext {
-    PSPDFKIT_VERSION = '5.5.0'
+    PSPDFKIT_VERSION = '5.5.1'
 }
 
 buildscript {
@@ -69,20 +69,11 @@ if (demoVersion) {
 }
 
 dependencies {
-    if (demoVersion) {
-        compile("com.pspdfkit:pspdfkit-demo:${PSPDFKIT_VERSION}") {
-            exclude group: 'com.google.auto.value', module: 'auto-value'
-        }
-        compile("com.pspdfkit:pspdfkit-instant-demo:${PSPDFKIT_VERSION}") {
-            exclude group: 'com.google.auto.value', module: 'auto-value'
-        }
-    } else {
-        compile("com.pspdfkit:pspdfkit:${PSPDFKIT_VERSION}") {
-            exclude group: 'com.google.auto.value', module: 'auto-value'
-        }
-        compile("com.pspdfkit:pspdfkit-instant:${PSPDFKIT_VERSION}") {
-            exclude group: 'com.google.auto.value', module: 'auto-value'
-        }
+    compile("com.pspdfkit:pspdfkit:${PSPDFKIT_VERSION}") {
+        exclude group: 'com.google.auto.value', module: 'auto-value'
+    }
+    compile("com.pspdfkit:pspdfkit-instant:${PSPDFKIT_VERSION}") {
+        exclude group: 'com.google.auto.value', module: 'auto-value'
     }
     compile "com.facebook.react:react-native:+"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.25.1",
+  "version": "1.25.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.25.1",
+  "version": "1.25.2",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.25.1",
+  "version": "1.25.2",
   "private": true,
   "scripts": {
     "start": "react-native start",


### PR DESCRIPTION
## Resolves #266 

# Details

With PSPDFKit 5.5.0 the demo artefact no longer exists so we have to always use the full artefact.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
