### PR TITLE
Fix hot reload breaking the PdfView

### DIFF
--- a/android/src/main/java/com/pspdfkit/views/PdfView.java
+++ b/android/src/main/java/com/pspdfkit/views/PdfView.java
@@ -248,7 +248,9 @@ public class PdfView extends FrameLayout {
     private void setupFragment() {
         if (fragmentTag != null && configuration != null && document != null) {
             PdfFragment pdfFragment = (PdfFragment) fragmentManager.findFragmentByTag(fragmentTag);
-            if (pdfFragment != null && pdfFragment.getArguments().getInt(ARG_ROOT_ID) != internalId) {
+            if (pdfFragment != null &&
+                (pdfFragment.getArguments() == null ||
+                pdfFragment.getArguments().getInt(ARG_ROOT_ID) != internalId)) {
                 // This is an orphaned fragment probably from a reload, get rid of it.
                 fragmentManager.beginTransaction()
                     .remove(pdfFragment)

--- a/android/src/main/java/com/pspdfkit/views/PdfView.java
+++ b/android/src/main/java/com/pspdfkit/views/PdfView.java
@@ -77,6 +77,9 @@ public class PdfView extends FrameLayout {
 
     private static final String FILE_SCHEME = "file:///";
 
+    /** Key to use when setting the id argument of PdfFragments created by this PdfView. */
+    private static final String ARG_ROOT_ID = "root_id";
+
     private FragmentManager fragmentManager;
     private EventDispatcher eventDispatcher;
     private String fragmentTag;
@@ -101,6 +104,9 @@ public class PdfView extends FrameLayout {
     private BehaviorSubject<PdfFragment> fragmentGetter = BehaviorSubject.create();
     @Nullable
     private PdfTextSelectionPopupToolbar textSelectionPopupToolbar;
+
+    /** An internal id we generate so we can track if fragments found belong to this specific PdfView instance. */
+    private int internalId;
 
     public PdfView(@NonNull Context context) {
         super(context);
@@ -158,6 +164,9 @@ public class PdfView extends FrameLayout {
 
         // Set a default configuration.
         configuration = new PdfActivityConfiguration.Builder(getContext()).build();
+
+        // Generate an id to set on all fragments created by the PdfView.
+        internalId = View.generateViewId();
     }
 
     public void inject(FragmentManager fragmentManager, EventDispatcher eventDispatcher) {
@@ -239,8 +248,18 @@ public class PdfView extends FrameLayout {
     private void setupFragment() {
         if (fragmentTag != null && configuration != null && document != null) {
             PdfFragment pdfFragment = (PdfFragment) fragmentManager.findFragmentByTag(fragmentTag);
+            if (pdfFragment != null && pdfFragment.getArguments().getInt(ARG_ROOT_ID) != internalId) {
+                // This is an orphaned fragment probably from a reload, get rid of it.
+                fragmentManager.beginTransaction()
+                    .remove(pdfFragment)
+                    .commitNow();
+                pdfFragment = null;
+            }
+
             if (pdfFragment == null) {
                 pdfFragment = PdfFragment.newInstance(document, this.configuration.getConfiguration());
+                // We put our internal id so we can track if this fragment belongs to us, used to handle orphaned fragments after hot reloads.
+                pdfFragment.getArguments().putInt(ARG_ROOT_ID, internalId);
                 prepareFragment(pdfFragment);
             } else {
                 View fragmentView = pdfFragment.getView();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.25.3",
+  "version": "1.25.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.25.3",
+  "version": "1.25.4",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.25.3",
+  "version": "1.25.4",
   "private": true,
   "scripts": {
     "start": "react-native start",


### PR DESCRIPTION
# Details

The issue was that when reloading the code `PdfFragment` attached by the `PdfView` were not removed. Later when creating a new `PdfView` with the same `fragmentTag` it would pick up the previous fragment causing the broken UI to appear.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
