### PR TITLE
React native Windows 0.59 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This wrapper requires a valid license of PSPDFKit. Licenses are per platform. Yo
 
 This wrapper exposes the most often used APIs from PSPDFKit. Many of our partners end up forking this wrapper and adding some custom code to achieve even greater integration with their products, using native code.
 
+_IMPORTANT_ : `react-native-pspdfkit` for windows does not yet support react-native 0.60.\*. Currently [`react-native-windows`][https://github.com/microsoft/react-native-windows/releases] is not keeping up pace with `react-native`, where the last official release was 0.60.\* and the last RC was 0.59.\*. We have tested and require 0.59.10 to keep version aligned as much as possible and will continue to support upon the `windows-support` branch.
+
 #### Announcements
 
 - [Announcement blog post](https://pspdfkit.com/blog/2016/react-native-module/)
@@ -658,8 +660,6 @@ Shows the pdf `document` from the local device filesystem, or your app's assets.
 - yarn
 - PSPDFKit for Windows.vsix (installed)
 - PowerShell
-
-_IMPORTANT_ : `react-native-pspdfkit` for windows does not yet support react-native 0.60.\*. Currently [`react-native-windows`][https://github.com/microsoft/react-native-windows/releases] is not keeping up pace with `react-native`, where the last official release was 0.60.\* and the last RC was 0.59.\*. We have tested and require 0.59.10 to keep version aligned as much as possible.
 
 #### Getting Started
 

--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ Shows the pdf `document` from the local device filesystem, or your app's assets.
 - PSPDFKit for Windows.vsix (installed)
 - PowerShell
 
-_IMPORTANT_ : `react-native-pspdfkit` for windows does not yet support react-native 0.59.\*. Currently [`react-native-windows`][https://github.com/microsoft/react-native-windows/releases] is not keeping up pace with `react-native`, where the last official release was 0.54.\* and the last RC was 0.57.\*. We have tested and require 0.57.0 to keep version aligned as much as possible.
+_IMPORTANT_ : `react-native-pspdfkit` for windows does not yet support react-native 0.60.\*. Currently [`react-native-windows`][https://github.com/microsoft/react-native-windows/releases] is not keeping up pace with `react-native`, where the last official release was 0.60.\* and the last RC was 0.59.\*. We have tested and require 0.59.10 to keep version aligned as much as possible.
 
 #### Getting Started
 
@@ -669,10 +669,10 @@ Let's create a simple app that integrates PSPDFKit and uses the react-native-psp
 2. Make sure `react-native-cli` is installed: `yarn global add react-native-cli`.
 3. Install Windows Tool for React Native: `yarn add global windows-build-tools`.
 4. Open `x64 Native Tools Command Prompt for VS 2017` program.
-5. Create the app with `react-native init --version=0.57.8 YourApp` in a location of your choice.
+5. Create the app with `react-native init --version=0.59.10 YourApp` in a location of your choice.
 6. Step into your newly created app folder: `cd YourApp`.
 7. Install the Windows helper plugin: `yarn add --dev rnpm-plugin-windows`.
-8. Install `react-native-pspdfkit` from GitHub: `yarn add github:PSPDFKit/react-native#windows-1.11.0`.
+8. Install `react-native-pspdfkit` from GitHub: `yarn add github:PSPDFKit/react-native#windows-support`.
 9. Install `react-native-fs` from GitHub: `yarn add react-native-fs`.
 10. Install all modules for Windows: `yarn install`. (Because of a [bug](https://github.com/yarnpkg/yarn/issues/2165) you may need to clean `yarn`'s cache with `yarn cache clean` before.)
 11. Initialize the windows project: `react-native windows`.
@@ -796,23 +796,11 @@ var styles = StyleSheet.create({
 1. Clone the repository. `git clone https://github.com/PSPDFKit/react-native.git`.
 2. From the command promt `cd react-native\samples\Catalog`.
 3. Make sure `react-native-cli` is installed: `yarn global add react-native-cli`.
-4. Downgrade `react-native` package to 0.57.8. Edit `package.json`
-
-```diff
-  "dependencies": {
-    "react-native-pspdfkit": "file:../../",
-    "react": "16.8.3",
--   "react-native": "0.59.9",
-+   "react-native": "0.57.8",
-    "react-native-camera": "2.9.0",
-    "react-native-fs": "2.13.3",
-```
-
-5. run `yarn install`. (Because of a [bug](https://github.com/yarnpkg/yarn/issues/2165) you may need to clean `yarn`'s cache with `yarn cache clean` before.)
-6. Open the UWP catalog solution in `react-native\samples\Catalog\windows`.
-7. Accept and install any required extensions when prompted.
-8. If the settings windows opens, click on `Developer` and selected `yes`.
-9. Create a new file resouce called `License.xaml` with your PSPDFKit license key at the top level of the project. (Replace `ENTER LICENSE KEY HERE` with your key)
+4. run `yarn install`. (Because of a [bug](https://github.com/yarnpkg/yarn/issues/2165) you may need to clean `yarn`'s cache with `yarn cache clean` before.)
+5. Open the UWP catalog solution in `react-native\samples\Catalog\windows`.
+6. Accept and install any required extensions when prompted.
+7. If the settings windows opens, click on `Developer` and selected `yes`.
+8. Create a new file resouce called `License.xaml` with your PSPDFKit license key at the top level of the project. (Replace `ENTER LICENSE KEY HERE` with your key)
 
 ```xaml
 	<ResourceDictionary

--- a/index.windows.js
+++ b/index.windows.js
@@ -74,7 +74,7 @@ class PSPDFKitView extends React.Component {
 
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.refs.pdfView),
-      UIManager.RCTPSPDFKitView.Commands.enterAnnotationCreationMode,
+      UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.enterAnnotationCreationMode,
       [requestId]
     );
 
@@ -97,7 +97,7 @@ class PSPDFKitView extends React.Component {
 
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.refs.pdfView),
-      UIManager.RCTPSPDFKitView.Commands.exitCurrentlyActiveMode,
+      UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.exitCurrentlyActiveMode,
       []
     );
 
@@ -120,7 +120,7 @@ class PSPDFKitView extends React.Component {
 
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.refs.pdfView),
-      UIManager.RCTPSPDFKitView.Commands.saveCurrentDocument,
+      UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.saveCurrentDocument,
       [requestId]
     );
 
@@ -146,7 +146,7 @@ class PSPDFKitView extends React.Component {
 
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.refs.pdfView),
-      UIManager.RCTPSPDFKitView.Commands.getAnnotations,
+      UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.getAnnotations,
       [requestId, pageIndex]
     );
 
@@ -172,7 +172,7 @@ class PSPDFKitView extends React.Component {
 
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.refs.pdfView),
-      UIManager.RCTPSPDFKitView.Commands.addAnnotation,
+      UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.addAnnotation,
       [requestId, annotation]
     );
 
@@ -198,7 +198,7 @@ class PSPDFKitView extends React.Component {
 
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.refs.pdfView),
-      UIManager.RCTPSPDFKitView.Commands.removeAnnotation,
+      UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.removeAnnotation,
       [requestId, annotation]
     );
 
@@ -221,7 +221,7 @@ class PSPDFKitView extends React.Component {
 
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.refs.pdfView),
-      UIManager.RCTPSPDFKitView.Commands.getToolbarItems,
+      UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.getToolbarItems,
       [requestId]
     );
 
@@ -248,7 +248,7 @@ class PSPDFKitView extends React.Component {
 
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.refs.pdfView),
-      UIManager.RCTPSPDFKitView.Commands.setToolbarItems,
+      UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.setToolbarItems,
       [requestId, toolbarItems]
     );
 

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -28,7 +28,7 @@ const RNFS = require("react-native-fs");
 import {YellowBox} from "react-native";
 
 YellowBox.ignoreWarnings([
-  "Warning: Invalid argument supplied to oneOf" // React native windows bug.
+  "Warning: Failed prop type: Invalid prop `accessibilityStates[0]`"
 ]);
 
 

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -7,12 +7,12 @@
   },
   "dependencies": {
     "react-native-pspdfkit": "file:../../",
-    "react": "16.8.3",
-    "react-native": "0.59.9",
+    "react": "16.8.6",
+    "react-native": "0.59.10",
     "react-native-camera": "2.9.0",
     "react-native-fs": "2.13.3",
     "react-native-qrcode-scanner": "^1.1.0",
-    "react-native-windows": "0.57.0-rc.5",
+    "react-native-windows": "0.59.0-rc.3",
     "react-navigation": "^1.0.3",
     "prop-types": "15.7.2"
   },


### PR DESCRIPTION
Fixes : https://github.com/PSPDFKit/react-native/issues/182

# Details
This PR brings support for react-native 0.59, react-native-windows now has RC support and tested well with minor adjustments to the wrapper.