### PR TITLE
Add autosaveEnabled configuration

### DIFF
--- a/android/src/main/java/com/pspdfkit/react/ConfigurationAdapter.java
+++ b/android/src/main/java/com/pspdfkit/react/ConfigurationAdapter.java
@@ -67,7 +67,7 @@ public class ConfigurationAdapter {
     private static final String PAGE_MODE_DOUBLE = "double";
     private static final String PAGE_MODE_AUTO = "automatic";
     private static final String FIRST_PAGE_ALWAYS_SINGLE = "firstPageAlwaysSingle";
-    private static final String AUTOSAVE_ENABLED = "autosaveEnabled";
+    private static final String AUTOSAVE_DISABLED = "disableAutomaticSaving";
 
     private final PdfActivityConfiguration.Builder configuration;
 
@@ -149,8 +149,8 @@ public class ConfigurationAdapter {
             if (configuration.hasKey(FIRST_PAGE_ALWAYS_SINGLE)) {
                 configureFirstPageAlwaysSingle(configuration.getBoolean(FIRST_PAGE_ALWAYS_SINGLE));
             }
-            if (configuration.hasKey(AUTOSAVE_ENABLED)) {
-                configureAutosaveEnabled(configuration.getBoolean(AUTOSAVE_ENABLED));
+            if (configuration.hasKey(AUTOSAVE_DISABLED)) {
+                configureAutosaveEnabled(!configuration.getBoolean(AUTOSAVE_DISABLED));
             }
         }
     }

--- a/android/src/main/java/com/pspdfkit/react/ConfigurationAdapter.java
+++ b/android/src/main/java/com/pspdfkit/react/ConfigurationAdapter.java
@@ -67,6 +67,7 @@ public class ConfigurationAdapter {
     private static final String PAGE_MODE_DOUBLE = "double";
     private static final String PAGE_MODE_AUTO = "automatic";
     private static final String FIRST_PAGE_ALWAYS_SINGLE = "firstPageAlwaysSingle";
+    private static final String AUTOSAVE_ENABLED = "autosaveEnabled";
 
     private final PdfActivityConfiguration.Builder configuration;
 
@@ -147,6 +148,9 @@ public class ConfigurationAdapter {
             }
             if (configuration.hasKey(FIRST_PAGE_ALWAYS_SINGLE)) {
                 configureFirstPageAlwaysSingle(configuration.getBoolean(FIRST_PAGE_ALWAYS_SINGLE));
+            }
+            if (configuration.hasKey(AUTOSAVE_ENABLED)) {
+                configureAutosaveEnabled(configuration.getBoolean(AUTOSAVE_ENABLED));
             }
         }
     }
@@ -327,6 +331,10 @@ public class ConfigurationAdapter {
 
     private void configureFirstPageAlwaysSingle(final boolean firstPageAlwaysSingle) {
         configuration.firstPageAlwaysSingle(firstPageAlwaysSingle);
+    }
+
+    private void configureAutosaveEnabled(final boolean autosaveEnabled) {
+        configuration.autosaveEnabled(autosaveEnabled);
     }
 
     public PdfActivityConfiguration build() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.25.7",
+  "version": "1.25.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.25.7",
+  "version": "1.25.8",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.25.7",
+  "version": "1.25.8",
   "private": true,
   "scripts": {
     "start": "react-native start",


### PR DESCRIPTION
## Resolves #282 

# Details

- This adds a new configuration option `autosaveEnabled` to match what iOS provides.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [x] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
