### PR TITLE
Update to UWP 2.3.1

### DIFF
--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -10,7 +10,7 @@
     "react": "16.8.6",
     "react-native": "0.59.10",
     "react-native-camera": "2.9.0",
-    "react-native-fs": "2.13.3",
+    "react-native-fs": "2.14.1",
     "react-native-qrcode-scanner": "^1.1.0",
     "react-native-windows": "0.59.0-rc.3",
     "react-navigation": "^1.0.3",

--- a/samples/Catalog/windows/Catalog/Catalog.csproj
+++ b/samples/Catalog/windows/Catalog/Catalog.csproj
@@ -263,7 +263,7 @@
     <SDKReference Include="Microsoft.VCLibs, Version=14.0">
       <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
     </SDKReference>
-    <SDKReference Include="PSPDFKitSDK, Version=2.2.0">
+    <SDKReference Include="PSPDFKitSDK, Version=2.3.1">
       <Name>PSPDFKit for UWP</Name>
     </SDKReference>
   </ItemGroup>

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitModule.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitModule.cs
@@ -97,14 +97,14 @@ namespace ReactNativePSPDFKit
         /// <param name="file">File to open</param>
         private async Task LoadFileAsync(StorageFile file)
         {
-            if (file == null) return;
-            if(_viewManager.PdfViewPage != null)
+            if (file == null) throw new Exception("File cannot be null");
+            if(_viewManager != null)
             {
-                await _viewManager.PdfViewPage.OpenFileAsync(file);
+                await _viewManager.OpenFileAsync(file);
             }
             else
             {
-                throw new Exception("PdfViewPage: is not ready or unavailable.");
+                throw new Exception("PDFViewManager: is not ready or unavailable.");
             }
         }
 

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/ReactNativePSPDFKit.csproj
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/ReactNativePSPDFKit.csproj
@@ -138,7 +138,7 @@
     <SDKReference Include="Microsoft.VCLibs, Version=14.0">
       <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
     </SDKReference>
-    <SDKReference Include="PSPDFKitSDK, Version=2.2.0">
+    <SDKReference Include="PSPDFKitSDK, Version=2.3.1">
       <Name>PSPDFKit for UWP</Name>
     </SDKReference>
   </ItemGroup>


### PR DESCRIPTION
# Details
With this update some `PdfView` lifetime issues came about. 

It made sense to pull out the logic to check if a file is stage to be open into the view manager as we cannot guarantee that the `PdfView` is ready to go. 
Along with this we do not track the open file in `PdfViewPage` but rely on `PdfView` to retrieve the document source. We throw and exception if anything other than a storage file is used because pspdfkit-react-native does not support this.

Removed an instance of showing a dialog rather than throwing up to the promise. 