### PR TITLE
Add Author name option.

### DIFF
--- a/index.windows.js
+++ b/index.windows.js
@@ -270,6 +270,10 @@ PSPDFKitView.propTypes = {
    */
   hideNavigationBar: PropTypes.bool,
   /**
+   * The name to appened to annotation creator name when annotations are created via the UI.
+   */
+  annotationAuthorName: PropTypes.string,
+  /**
    * Callback that is called when an annotation is added, changed, or removed.
    * Returns an object with the following structure:
    * {

--- a/index.windows.js
+++ b/index.windows.js
@@ -270,7 +270,7 @@ PSPDFKitView.propTypes = {
    */
   hideNavigationBar: PropTypes.bool,
   /**
-   * The name to appened to annotation creator name when annotations are created via the UI.
+   * The  creator name to add when annotations are created via the UI.
    */
   annotationAuthorName: PropTypes.string,
   /**

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -379,6 +379,7 @@ class PdfViewInstantJsonScreen extends Component<{}> {
           style={styles.pdfView}
           // The default file to open.
           document="ms-appx:///Assets/pdf/annualReport.pdf"
+          annotationAuthorName="Joe Smith"
         />
         <View
           style={{

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PDFViewPage.xaml.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PDFViewPage.xaml.cs
@@ -15,6 +15,7 @@ using Windows.Data.Json;
 using PSPDFKit.UI;
 using Windows.Storage;
 using Windows.UI.Xaml.Controls;
+using PSPDFKit.Pdf;
 using PSPDFKit.Pdf.Annotation;
 using ReactNative.UIManager;
 using ReactNativePSPDFKit.Events;
@@ -25,6 +26,7 @@ namespace ReactNativePSPDFKit
     {
         private bool _pdfViewInitialized = false;
         public readonly PdfView PdfView;
+        private string _annotationCreatorName = null;
 
         public PDFViewPage()
         {
@@ -181,13 +183,32 @@ namespace ReactNativePSPDFKit
             PDFView.ShowToolbar = showToolbar;
         }
 
-        private void PDFView_InitializationCompletedHandlerAsync(PdfView sender, PSPDFKit.Pdf.Document document)
+        public void SetAnnotationCreatorName(string annotationAuthorName)
+        {
+            _annotationCreatorName = annotationAuthorName;
+        }
+
+        private void PDFView_InitializationCompletedHandlerAsync(PdfView sender, Document document)
         {
             _pdfViewInitialized = true;
         }
 
-        private void DocumentOnAnnotationsCreated(object sender, IList<IAnnotation> annotations)
+        private async void DocumentOnAnnotationsCreated(Document document, IList<IAnnotation> annotations)
         {
+            // If we have an author name set, we want to add this.
+            if (_annotationCreatorName != null)
+            {
+                foreach (var annotation in annotations)
+                {
+                    // If the create name is populated then it probably was created else where. 
+                    if (annotation.CreatorName == null)
+                    {
+                        annotation.CreatorName = _annotationCreatorName;
+                        await document.UpdateAnnotationAsync(annotation);
+                    }
+                }
+            }
+
             this.GetReactContext().GetNativeModule<UIManagerModule>().EventDispatcher.DispatchEvent(
                 new PdfViewAnnotationChangedEvent(this.GetTag(),
                     PdfViewAnnotationChangedEvent.EVENT_TYPE_ADDED, annotations)

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitViewManager.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitViewManager.cs
@@ -85,6 +85,12 @@ namespace ReactNativePSPDFKit
             view.SetShowToolbar(!hideNavigationBar);
         }
 
+        [ReactProp("annotationAuthorName")]
+        public void SetAnnotationAuthorName(PDFViewPage view, string annotationAuthorName)
+        {
+            view.SetAnnotationCreatorName(annotationAuthorName);
+        }
+
         /// <summary>
         /// Take the file and call the controller to open the document.
         /// </summary>


### PR DESCRIPTION
Fixes : https://github.com/PSPDFKit/react-native/issues/281

# Details
This PR adds the `annotationAuthorName` prop to `PSPDFKitView` so a creator name is added to each annotation that is created in the `react-native` instance. If no name is set then creator name will be `null`.