### PR TITLE
Get All Annotations

### DIFF
--- a/index.windows.js
+++ b/index.windows.js
@@ -151,31 +151,31 @@ class PSPDFKitView extends React.Component {
     );
 
     return promise;
-    }
+  }
 
-    /**
-     * Gets all annotations for the document.
-     *
-     * @returns a promise resolving an array with the following structure:
-     * {'annotations' : [instantJson]}
-     */
-    getAllAnnotations() {
-        let requestId = this._nextRequestId++;
-        let requestMap = this._requestMap;
+  /**
+   * Gets all annotations for the document.
+   *
+   * @returns a promise resolving an array with the following structure:
+   * {'annotations' : [instantJson]}
+   */
+  getAllAnnotations() {
+    let requestId = this._nextRequestId++;
+    let requestMap = this._requestMap;
 
-        // We create a promise here that will be resolved once onDataReturned is called.
-        let promise = new Promise((resolve, reject) => {
-            requestMap[requestId] = { resolve: resolve, reject: reject };
-        });
+    // We create a promise here that will be resolved once onDataReturned is called.
+    let promise = new Promise((resolve, reject) => {
+      requestMap[requestId] = {resolve: resolve, reject: reject};
+    });
 
-        UIManager.dispatchViewManagerCommand(
-            findNodeHandle(this.refs.pdfView),
-            UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.getAllAnnotations,
-            [requestId]
-        );
+    UIManager.dispatchViewManagerCommand(
+      findNodeHandle(this.refs.pdfView),
+      UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.getAllAnnotations,
+      [requestId]
+    );
 
-        return promise;
-    }
+    return promise;
+  }
 
   /**
    * Adds a new annotation to the current document.

--- a/index.windows.js
+++ b/index.windows.js
@@ -151,7 +151,31 @@ class PSPDFKitView extends React.Component {
     );
 
     return promise;
-  }
+    }
+
+    /**
+     * Gets all annotations for the document.
+     *
+     * @returns a promise resolving an array with the following structure:
+     * {'annotations' : [instantJson]}
+     */
+    getAllAnnotations() {
+        let requestId = this._nextRequestId++;
+        let requestMap = this._requestMap;
+
+        // We create a promise here that will be resolved once onDataReturned is called.
+        let promise = new Promise((resolve, reject) => {
+            requestMap[requestId] = { resolve: resolve, reject: reject };
+        });
+
+        UIManager.dispatchViewManagerCommand(
+            findNodeHandle(this.refs.pdfView),
+            UIManager.getViewManagerConfig('RCTPSPDFKitView').Commands.getAllAnnotations,
+            [requestId]
+        );
+
+        return promise;
+    }
 
   /**
    * Adds a new annotation to the current document.

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -396,9 +396,20 @@ class PdfViewInstantJsonScreen extends Component<{}> {
                   alert(JSON.stringify(annotations));
                 });
               }}
-              title="Get Annotations"
+              title="Get Annotations Page 1"
             />
-          </View>
+                </View>
+    <View style={{ marginLeft: 10 }}>
+<Button
+onPress={() => {
+    // This gets all annotations on the document.¬
+    this.refs.pdfView.getAllAnnotations().then(annotations => {
+        alert(JSON.stringify(annotations));
+    });
+}}
+title="Get All Annotation"
+    />
+    </View>
           <View style={{marginLeft: 10}}>
             <Button
               onPress={() => {

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -398,18 +398,18 @@ class PdfViewInstantJsonScreen extends Component<{}> {
               }}
               title="Get Annotations Page 1"
             />
-                </View>
-    <View style={{ marginLeft: 10 }}>
-<Button
-onPress={() => {
-    // This gets all annotations on the document.¬
-    this.refs.pdfView.getAllAnnotations().then(annotations => {
-        alert(JSON.stringify(annotations));
-    });
-}}
-title="Get All Annotation"
-    />
-    </View>
+          </View>
+          <View style={{marginLeft: 10}}>
+            <Button
+              onPress={() => {
+                // This gets all annotations on the document.¬
+                this.refs.pdfView.getAllAnnotations().then(annotations => {
+                  alert(JSON.stringify(annotations));
+                });
+              }}
+              title="Get All Annotation"
+            />
+          </View>
           <View style={{marginLeft: 10}}>
             <Button
               onPress={() => {

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -407,7 +407,7 @@ class PdfViewInstantJsonScreen extends Component<{}> {
                   alert(JSON.stringify(annotations));
                 });
               }}
-              title="Get All Annotation"
+              title="Get All Annotations"
             />
           </View>
           <View style={{marginLeft: 10}}>

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PDFViewPage.xaml.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PDFViewPage.xaml.cs
@@ -94,6 +94,24 @@ namespace ReactNativePSPDFKit
             }
         }
 
+        internal async Task GetAllAnnotations(int requestId)
+        {
+            try
+            {
+                var annotations = await PdfView.Document.GetAnnotationsAsync();
+
+                this.GetReactContext().GetNativeModule<UIManagerModule>().EventDispatcher.DispatchEvent(
+                    new PdfViewDataReturnedEvent(this.GetTag(), requestId, annotations)
+                );
+            }
+            catch (Exception e)
+            {
+                this.GetReactContext().GetNativeModule<UIManagerModule>().EventDispatcher.DispatchEvent(
+                    new PdfViewDataReturnedEvent(this.GetTag(), requestId, e.Message)
+                );
+            }
+        }
+
         internal void GetToolbarItems(int requestId)
         {
             try

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitViewManager.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitViewManager.cs
@@ -29,6 +29,7 @@ namespace ReactNativePSPDFKit
         private const int COMMAND_GET_TOOLBAR_ITEMS = 6;
         private const int COMMAND_SET_TOOLBAR_ITEMS = 7;
         private const int COMMAND_REMOVE_ANNOTATION = 8;
+        private const int COMMAND_GET_ALL_ANNOTATIONS = 9;
 
         private readonly Uri _cssResource = null;
         internal PDFViewPage PdfViewPage;
@@ -85,6 +86,12 @@ namespace ReactNativePSPDFKit
             view.SetShowToolbar(!hideNavigationBar);
         }
 
+        [ReactProp("annotationAuthorName")]
+        public void SetAnnotationAuthorName(PDFViewPage view, string annotationAuthorName)
+        {
+            view.SetAnnotationCreatorName(annotationAuthorName);
+        }
+
         /// <summary>
         /// Take the file and call the controller to open the document.
         /// </summary>
@@ -115,6 +122,9 @@ namespace ReactNativePSPDFKit
                 "getAnnotations", COMMAND_GET_ANNOTATIONS
             },
             {
+                "getAllAnnotations", COMMAND_GET_ALL_ANNOTATIONS
+            },
+            {
                 "addAnnotation", COMMAND_ADD_ANNOTATION
             },
             {
@@ -143,6 +153,9 @@ namespace ReactNativePSPDFKit
                     break;
                 case COMMAND_GET_ANNOTATIONS:
                     await view.GetAnnotations(args[0].Value<int>(), args[1].Value<int>());
+                    break;
+                case COMMAND_GET_ALL_ANNOTATIONS:
+                    await view.GetAllAnnotations(args[0].Value<int>());
                     break;
                 case COMMAND_ADD_ANNOTATION:
                     await view.CreateAnnotation(args[0].Value<int>(), args[1].ToString());


### PR DESCRIPTION
Fixes : https://github.com/PSPDFKit/react-native/issues/167

# Details
Implements `getAllAnnotations` to make it simpler to retrieve all the annotations for a given document.
