### PR TITLE
Force UIModalPresentationOverFullScreen for the native module on iOS 13

### DIFF
--- a/ios/RCTPSPDFKit/RCTPSPDFKitManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitManager.m
@@ -31,6 +31,7 @@ RCT_EXPORT_METHOD(present:(PSPDFDocument *)document withConfiguration:(PSPDFConf
 
   UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:pdfViewController];
 
+  navigationController.modalPresentationStyle = UIModalPresentationOverFullScreen;
   UIViewController *presentingViewController = RCTPresentedViewController();
   [presentingViewController presentViewController:navigationController animated:YES completion:nil];
 }

--- a/ios/RCTPSPDFKit/RCTPSPDFKitManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitManager.m
@@ -31,7 +31,7 @@ RCT_EXPORT_METHOD(present:(PSPDFDocument *)document withConfiguration:(PSPDFConf
 
   UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:pdfViewController];
 
-  navigationController.modalPresentationStyle = UIModalPresentationOverFullScreen;
+  navigationController.modalPresentationStyle = UIModalPresentationFullScreen;
   UIViewController *presentingViewController = RCTPresentedViewController();
   [presentingViewController presentViewController:navigationController animated:YES completion:nil];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "private": true,
   "scripts": {
     "start": "react-native start",


### PR DESCRIPTION
# Details

## How to Reproduce:

Use the native module to present a document (`PSPDFKit.present()`) on iOS 13.

| **Before** | **After** |
| --- | --- |
| <img width="584" alt="Screen Shot 2019-10-02 at 11 58 55 AM" src="https://user-images.githubusercontent.com/7443038/66061178-ee2ff780-e50c-11e9-8602-f2b7f564e1ff.png"> | <img width="584" alt="Screen Shot 2019-10-02 at 12 01 17 PM" src="https://user-images.githubusercontent.com/7443038/66061189-f425d880-e50c-11e9-969b-67b55397bdb0.png"> |

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
