### PR TITLE
Make saveCurrentDocument and setFormFieldValue return a promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,15 +131,27 @@ class PSPDFKitView extends React.Component {
 
   /**
    * Saves the currently opened document.
+   *
+   * Returns a promise resolving to true if the document was saved, and false otherwise.
    */
   saveCurrentDocument = function() {
     if (Platform.OS === "android") {
+      let requestId = this._nextRequestId++;
+      let requestMap = this._requestMap;
+
+      // We create a promise here that will be resolved once onDataReturned is called.
+      let promise = new Promise(function(resolve, reject) {
+        requestMap[requestId] = { resolve: resolve, reject: reject };
+      });
+
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
         this._getViewManagerConfig("RCTPSPDFKitView").Commands
           .saveCurrentDocument,
-        []
+        [requestId]
       );
+
+      return promise;
     } else if (Platform.OS === "ios") {
       return NativeModules.PSPDFKitViewManager.saveCurrentDocument(
         findNodeHandle(this.refs.pdfView)
@@ -381,15 +393,27 @@ class PSPDFKitView extends React.Component {
    *
    * @param fullyQualifiedName The fully qualified name of the form element.
    * @param value The string value form element. For button form elements pass 'selected' or 'deselected'. For choice form elements, pass the index of the choice to select, for example '1'.
+   *
+   * Returns a promise resolving to true if the value was set, and false otherwise.
    */
   setFormFieldValue = function(fullyQualifiedName, value) {
     if (Platform.OS === "android") {
+      let requestId = this._nextRequestId++;
+      let requestMap = this._requestMap;
+
+      // We create a promise here that will be resolved once onDataReturned is called.
+      let promise = new Promise(function(resolve, reject) {
+        requestMap[requestId] = { resolve: resolve, reject: reject };
+      });
+
       UIManager.dispatchViewManagerCommand(
         findNodeHandle(this.refs.pdfView),
         this._getViewManagerConfig("RCTPSPDFKitView").Commands
           .setFormFieldValue,
-        [fullyQualifiedName, value]
+        [requestId, fullyQualifiedName, value]
       );
+
+      return promise;
     } else if (Platform.OS === "ios") {
       NativeModules.PSPDFKitViewManager.setFormFieldValue(
         value,

--- a/index.js
+++ b/index.js
@@ -415,7 +415,7 @@ class PSPDFKitView extends React.Component {
 
       return promise;
     } else if (Platform.OS === "ios") {
-      NativeModules.PSPDFKitViewManager.setFormFieldValue(
+      return NativeModules.PSPDFKitViewManager.setFormFieldValue(
         value,
         fullyQualifiedName,
         findNodeHandle(this.refs.pdfView)

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.h
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.h
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Forms
 - (NSDictionary<NSString *, NSString *> *)getFormFieldValue:(NSString *)fullyQualifiedName;
-- (void)setFormFieldValue:(NSString *)value fullyQualifiedName:(NSString *)fullyQualifiedName;
+- (BOOL)setFormFieldValue:(NSString *)value fullyQualifiedName:(NSString *)fullyQualifiedName;
 
 // Toolbar buttons customizations
 - (void)setLeftBarButtonItems:(nullable NSArray <NSString *> *)items forViewMode:(nullable NSString *) viewMode animated:(BOOL)animated;

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -310,35 +310,43 @@
   return @{@"error": @"Failed to get the form field value."};
 }
 
-- (void)setFormFieldValue:(NSString *)value fullyQualifiedName:(NSString *)fullyQualifiedName {
+- (BOOL)setFormFieldValue:(NSString *)value fullyQualifiedName:(NSString *)fullyQualifiedName {
   if (fullyQualifiedName.length == 0) {
     NSLog(@"Invalid fully qualified name.");
-    return;
+    return NO;
   }
   
   PSPDFDocument *document = self.pdfController.document;
-  VALIDATE_DOCUMENT(document)
-  
+  VALIDATE_DOCUMENT(document, NO)
+
+  BOOL success = NO;
   for (PSPDFFormElement *formElement in document.formParser.forms) {
     if ([formElement.fullyQualifiedFieldName isEqualToString:fullyQualifiedName]) {
       if ([formElement isKindOfClass:PSPDFButtonFormElement.class]) {
         if ([value isEqualToString:@"selected"]) {
           [(PSPDFButtonFormElement *)formElement select];
+          success = YES;
         } else if ([value isEqualToString:@"deselected"]) {
           [(PSPDFButtonFormElement *)formElement deselect];
+          success = YES;
         }
       } else if ([formElement isKindOfClass:PSPDFChoiceFormElement.class]) {
         ((PSPDFChoiceFormElement *)formElement).selectedIndices = [NSIndexSet indexSetWithIndex:value.integerValue];
+        success = YES;
       } else if ([formElement isKindOfClass:PSPDFTextFieldFormElement.class]) {
         formElement.contents = value;
+        success = YES;
       } else if ([formElement isKindOfClass:PSPDFSignatureFormElement.class]) {
         NSLog(@"Signature form elements are not supported.");
+        success = NO;
       } else {
         NSLog(@"Unsupported form element.");
+        success = NO;
       }
       break;
     }
   }
+  return success;
 }
 
 #pragma mark - Notifications

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -233,10 +233,15 @@ RCT_EXPORT_METHOD(getFormFieldValue:(NSString *)fullyQualifiedName reactTag:(non
   });
 }
 
-RCT_EXPORT_METHOD(setFormFieldValue:(nullable NSString *)value fullyQualifiedName:(NSString *)fullyQualifiedName reactTag:(nonnull NSNumber *)reactTag) {
+RCT_EXPORT_METHOD(setFormFieldValue:(nullable NSString *)value fullyQualifiedName:(NSString *)fullyQualifiedName reactTag:(nonnull NSNumber *)reactTag resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   dispatch_async(dispatch_get_main_queue(), ^{
     RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];
-    [component setFormFieldValue:value fullyQualifiedName:fullyQualifiedName];
+    BOOL success = [component setFormFieldValue:value fullyQualifiedName:fullyQualifiedName];
+     if (success) {
+       resolve(@(success));
+     } else {
+       reject(@"error", @"Failed to set form field value.", nil);
+     }
   });
 }
 

--- a/samples/Catalog/Catalog.android.js
+++ b/samples/Catalog/Catalog.android.js
@@ -712,24 +712,30 @@ class PdfViewFormFillingScreen extends Component<{}> {
             <Button
               onPress={() => {
                 // Fill Text Form Fields.
-                this.refs.pdfView.setFormFieldValue("Name_Last", "Appleseed");
-                this.refs.pdfView.setFormFieldValue("Name_First", "John");
-                this.refs.pdfView.setFormFieldValue(
-                  "Address_1",
-                  "1 Infinite Loop"
-                );
-                this.refs.pdfView.setFormFieldValue("City", "Cupertino");
-                this.refs.pdfView.setFormFieldValue("STATE", "CA");
-                this.refs.pdfView.setFormFieldValue("SSN", "123456789");
-                this.refs.pdfView.setFormFieldValue(
-                  "Telephone_Home",
-                  "(123) 456-7890"
-                );
-                this.refs.pdfView.setFormFieldValue("Birthdate", "1/1/1983");
+                Promise.all(
+                  this.refs.pdfView.setFormFieldValue("Name_Last", "Appleseed"),
+                  this.refs.pdfView.setFormFieldValue("Name_First", "John"),
+                  this.refs.pdfView.setFormFieldValue(
+                    "Address_1",
+                    "1 Infinite Loop"
+                  ),
+                  this.refs.pdfView.setFormFieldValue("City", "Cupertino"),
+                  this.refs.pdfView.setFormFieldValue("STATE", "CA"),
+                  this.refs.pdfView.setFormFieldValue("SSN", "123456789"),
+                  this.refs.pdfView.setFormFieldValue(
+                    "Telephone_Home",
+                    "(123) 456-7890"
+                  ),
+                  this.refs.pdfView.setFormFieldValue("Birthdate", "1/1/1983"),
 
-                // Select a button form elements.
-                this.refs.pdfView.setFormFieldValue("Sex.0", "selected");
-                this.refs.pdfView.setFormFieldValue("PHD", "selected");
+                  // Select a button form elements.
+                  this.refs.pdfView.setFormFieldValue("Sex.0", "selected"),
+                  this.refs.pdfView.setFormFieldValue("PHD", "selected")
+                ).then(result => {
+                  // Called when all form field values were set.
+                  // If you want to fill forms then save the document this is the place to do it.
+                  alert("All forms filled!");
+                });
               }}
               title="Fill Forms"
             />

--- a/samples/Catalog/Catalog.ios.js
+++ b/samples/Catalog/Catalog.ios.js
@@ -477,7 +477,18 @@ class ManualSave extends Component {
             <Button
               onPress={() => {
                 // Manual Save
-                this.refs.pdfView.saveCurrentDocument();
+                this.refs.pdfView
+                  .saveCurrentDocument()
+                  .then(result => {
+                    if (result) {
+                      alert("Successfully saved current document.");
+                    } else {
+                      alert("Failed to save current document.");
+                    }
+                  })
+                  .catch(error => {
+                    alert(JSON.stringify(error));
+                  });
               }}
               title="Save"
             />
@@ -835,24 +846,128 @@ class ProgrammaticFormFilling extends Component {
             <Button
               onPress={() => {
                 // Fill Text Form Fields.
-                this.refs.pdfView.setFormFieldValue("Name_Last", "Appleseed");
-                this.refs.pdfView.setFormFieldValue("Name_First", "John");
-                this.refs.pdfView.setFormFieldValue(
-                  "Address_1",
-                  "1 Infinite Loop"
-                );
-                this.refs.pdfView.setFormFieldValue("City", "Cupertino");
-                this.refs.pdfView.setFormFieldValue("STATE", "CA");
-                this.refs.pdfView.setFormFieldValue("SSN", "123456789");
-                this.refs.pdfView.setFormFieldValue(
-                  "Telephone_Home",
-                  "(123) 456-7890"
-                );
-                this.refs.pdfView.setFormFieldValue("Birthdate", "1/1/1983");
+                this.refs.pdfView
+                  .setFormFieldValue("Name_Last", "Appleseed")
+                  .then(result => {
+                    if (result) {
+                      console.log("Successfully set the form field value.");
+                    } else {
+                      alert("Failed to set form field value.");
+                    }
+                  })
+                  .catch(error => {
+                    alert(JSON.stringify(error));
+                  });
+                this.refs.pdfView
+                  .setFormFieldValue("Name_First", "John")
+                  .then(result => {
+                    if (result) {
+                      console.log("Successfully set the form field value.");
+                    } else {
+                      alert("Failed to set form field value.");
+                    }
+                  })
+                  .catch(error => {
+                    alert(JSON.stringify(error));
+                  });
+                this.refs.pdfView
+                  .setFormFieldValue("Address_1", "1 Infinite Loop")
+                  .then(result => {
+                    if (result) {
+                      console.log("Successfully set the form field value.");
+                    } else {
+                      alert("Failed to set form field value.");
+                    }
+                  })
+                  .catch(error => {
+                    alert(JSON.stringify(error));
+                  });
+                this.refs.pdfView
+                  .setFormFieldValue("City", "Cupertino")
+                  .then(result => {
+                    if (result) {
+                      console.log("Successfully set the form field value.");
+                    } else {
+                      alert("Failed to set form field value.");
+                    }
+                  })
+                  .catch(error => {
+                    alert(JSON.stringify(error));
+                  });
+                this.refs.pdfView
+                  .setFormFieldValue("STATE", "CA")
+                  .then(result => {
+                    if (result) {
+                      console.log("Successfully set the form field value.");
+                    } else {
+                      alert("Failed to set form field value.");
+                    }
+                  })
+                  .catch(error => {
+                    alert(JSON.stringify(error));
+                  });
+                this.refs.pdfView
+                  .setFormFieldValue("SSN", "123456789")
+                  .then(result => {
+                    if (result) {
+                      console.log("Successfully set the form field value.");
+                    } else {
+                      alert("Failed to set form field value.");
+                    }
+                  })
+                  .catch(error => {
+                    alert(JSON.stringify(error));
+                  });
+                this.refs.pdfView
+                  .setFormFieldValue("Telephone_Home", "(123) 456-7890")
+                  .then(result => {
+                    if (result) {
+                      console.log("Successfully set the form field value.");
+                    } else {
+                      alert("Failed to set form field value.");
+                    }
+                  })
+                  .catch(error => {
+                    alert(JSON.stringify(error));
+                  });
+                this.refs.pdfView
+                  .setFormFieldValue("Birthdate", "1/1/1983")
+                  .then(result => {
+                    if (result) {
+                      console.log("Successfully set the form field value.");
+                    } else {
+                      alert("Failed to set form field value.");
+                    }
+                  })
+                  .catch(error => {
+                    alert(JSON.stringify(error));
+                  });
 
                 // Select a button form elements.
-                this.refs.pdfView.setFormFieldValue("Sex.0", "selected");
-                this.refs.pdfView.setFormFieldValue("PHD", "selected");
+                this.refs.pdfView
+                  .setFormFieldValue("Sex.0", "selected")
+                  .then(result => {
+                    if (result) {
+                      console.log("Successfully set the form field value.");
+                    } else {
+                      alert("Failed to set form field value.");
+                    }
+                  })
+                  .catch(error => {
+                    alert(JSON.stringify(error));
+                  });
+                this.refs.pdfView
+                  .setFormFieldValue("PHD", "selected")
+                  .then(result => {
+                    if (result) {
+                      console.log("Successfully set the form field value.");
+                    } else {
+                      alert("Failed to set form field value.");
+                    }
+                  })
+                  .catch(error => {
+                    alert(JSON.stringify(error));
+                  });
               }}
               title="Fill Forms"
             />


### PR DESCRIPTION
# Details

Makes `saveCurrentDocument` and `setFormFieldValue` return a promise so you can more easily chain operations as `setFormFieldValue` does not execute instantly.

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
