### PR TITLE
Add the annotation name to the `onAnnotationsChanged` payload when annotation is removed on iOS

### DIFF
--- a/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFAnnotation.m
+++ b/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFAnnotation.m
@@ -24,7 +24,7 @@
       }
     } else {
       // We only generate Instant JSON data for attached annotations. When an annotation is deleted, we only set the annotation uuid and name.
-      [annotationsJSON addObject:@{@"uuid" : annotation.uuid, @"name" : annotation.name ?: annotation.uuid}];
+      [annotationsJSON addObject:@{@"uuid" : annotation.uuid, @"name" : annotation.name ?: [NSNull new]}];
     }
   }
   

--- a/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFAnnotation.m
+++ b/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFAnnotation.m
@@ -23,8 +23,8 @@
         [annotationsJSON addObject:annotationDictionary];
       }
     } else {
-      // We only generate Instant JSON data for attached annotations. When an annotation is deleted, we only set the annotation uuid.
-      [annotationsJSON addObject:uuidDict];
+      // We only generate Instant JSON data for attached annotations. When an annotation is deleted, we only set the annotation uuid and name.
+      [annotationsJSON addObject:@{@"uuid" : annotation.uuid, @"name" : annotation.name ?: annotation.uuid}];
     }
   }
   

--- a/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFAnnotation.m
+++ b/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFAnnotation.m
@@ -24,7 +24,7 @@
       }
     } else {
       // We only generate Instant JSON data for attached annotations. When an annotation is deleted, we only set the annotation uuid and name.
-      [annotationsJSON addObject:@{@"uuid" : annotation.uuid, @"name" : annotation.name ?: [NSNull new]}];
+      [annotationsJSON addObject:@{@"uuid" : annotation.uuid, @"name" : annotation.name ?: [NSNull null]}];
     }
   }
   


### PR DESCRIPTION
This is the iOS implementation for #283

---

# Details

This is the payload that we send on iOS for `onAnnotationsChanged` when an annotation is removed:

```
{
  change: 'removed',
  annotations: [
    {
      uuid: '2D28DCB5-002B-4B5A-843F-F142D618838F',
      name: '2D28DCB5-002B-4B5A-843F-F142D618838F',
    }
  ]
}
```

An this is the Android payload:

```
{
  change: 'removed',
  annotations: [
    {
      name: '2D28DCB5-002B-4B5A-843F-F142D618838F',
    }
  ]
}
```

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
