### PR TITLE
Fix `enableAnnotationEditing` on iOS

### DIFF
--- a/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFConfiguration.m
+++ b/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFConfiguration.m
@@ -361,7 +361,7 @@ RCT_MULTI_ENUM_CONVERTER(PSPDFDocumentSharingPagesOptions,
     self.searchMode = [RCTConvert BOOL:dictionary[@"inlineSearch"]] ? PSPDFSearchModeInline : PSPDFSearchModeModal;
   }
 
-  if (dictionary[@"enableAnnotationEditing"] && [RCTConvert BOOL:dictionary[@"enableAnnotationEditing"]]) {
+  if (dictionary[@"enableAnnotationEditing"] && ![RCTConvert BOOL:dictionary[@"enableAnnotationEditing"]]) {
     self.editableAnnotationTypes = nil;
   }
 


### PR DESCRIPTION
# Details

When `enableAnnotationEditing` is set to false, we internally set `editableAnnotationTypes` to nil. The condition was wrong! 🤦‍♂ 

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
