### PR TITLE
added multiDexEnabledProperty in order to create test build using Detox

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,7 @@ android {
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
+	      multiDexEnabled true
     }
 
     compileOptions {


### PR DESCRIPTION
# Details
Hello, I created issue https://github.com/PSPDFKit/react-native/issues/314
I have problem creating test build using Detox. Error: PSPDFKit exceeds 65k limit and cant be put in single dex. After setting `multiDexEnabled true` I could create test build using detox. Now I want to run detox using BitRise. That is why I need that property to be set on original repo. 

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, and `samples/Catalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
