### PR TITLE
Enable Annotation Editing support in UWP

### DIFF
--- a/index.windows.js
+++ b/index.windows.js
@@ -290,6 +290,11 @@ PSPDFKitView.propTypes = {
    */
   pageIndex: PropTypes.number,
   /**
+   * Configuration object, to customize the appearance and behavior of PSPDFKit.
+   * Currently only takes `{{enableAnnotationEditing: false/true}}`
+   */
+  configuration: PropTypes.object,
+  /**
    * Controls whether a navigation bar is created and shown or not. Defaults to showing a navigation bar (false).
    */
   hideNavigationBar: PropTypes.bool,

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -32,8 +32,8 @@ YellowBox.ignoreWarnings([
 ]);
 
 const CONFIGURATION = {
-    // Settings this to false will disable all annotation editing
-    enableAnnotationEditing: true
+  // Settings this to false will disable all annotation editing
+  enableAnnotationEditing: true
 };
 
 const complexSearchConfiguration = {
@@ -105,7 +105,7 @@ const examples = [
       // Present can only take files loaded in the Visual studio Project's Assets. Please use RNFS.
       // See https://docs.microsoft.com/en-us/windows/uwp/files/file-access-permissions
       const path = RNFS.MainBundlePath + "\\Assets\\pdf\\Business Report.pdf";
-        PSPDFKit.Present(path, {})
+      PSPDFKit.Present(path, {})
         .then(() => {
           alert("File Opened successfully");
         })
@@ -168,15 +168,15 @@ const examples = [
     action: async component => {
       component.props.navigation.navigate("PdfViewDisableAnnotationEditing");
     }
-    },
-    {
-        key: "item8",
-        name: "Disable Annotation Editing",
-        description: "An example to show how to globally disable annotation editing.",
-        action: async component => {
-            component.props.navigation.navigate("PdfViewDisableAnnotationEditing");
-        }
-    },
+  },
+  {
+    key: "item8",
+    name: "Disable Annotation Editing",
+    description: "An example to show how to globally disable annotation editing.",
+    action: async component => {
+      component.props.navigation.navigate("PdfViewDisableAnnotationEditing");
+    }
+  },
   {
     key: "item9",
     name: "Custom colors",
@@ -318,8 +318,8 @@ class PdfViewScreen extends Component<{}> {
           ref="pdfView"
           style={styles.pdfView}
           // The default file to open.
-            document="ms-appx:///Assets/pdf/annualReport.pdf"
-                />
+          document="ms-appx:///Assets/pdf/annualReport.pdf"
+        />
         <View style={styles.footer}>
           <View style={styles.button}>
             <Button onPress={() => PSPDFKit.OpenFilePicker()} title="Open"/>
@@ -498,36 +498,36 @@ class PdfViewToolbarCustomizationScreen extends Component<{}> {
 }
 
 class PdfViewDisableAnnotationEditingScreen extends Component<{}> {
-    render() {
-        return (
-        <View style={styles.page}>
-            <PSPDFKitView
-                    ref="pdfView"
-                    style={styles.pdfView}
-                    // The default file to open.
-                    document="ms-appx:///Assets/pdf/annualReport.pdf"
-                    configuration={{ enableAnnotationEditing: false}}
-                />
-    <View style={styles.footer}>
-<View style={styles.buttonRow}>
-    <View style={styles.button}>
-                            <Button onPress={() => {
-    const path = RNFS.MainBundlePath + "\\Assets\\pdf\\Business Report.pdf";
-    PSPDFKit.Present(path, CONFIGURATION);
-}} title="Reload and Enable Editing" />
-    </View> 
-    </View>
-    <Image
-source={require("./assets/logo-flat.png")}
-style={styles.logo}
-    />
-    <Text style={styles.version}>
-    SDK Version : {PSPDFKit.versionString}
-</Text>
-    </View>
-    </View>
-);
-}
+  render() {
+    return (
+      <View style={styles.page}>
+        <PSPDFKitView
+          ref="pdfView"
+          style={styles.pdfView}
+          // The default file to open.
+          document="ms-appx:///Assets/pdf/annualReport.pdf"
+          configuration={{enableAnnotationEditing: false}}
+        />
+        <View style={styles.footer}>
+          <View style={styles.buttonRow}>
+            <View style={styles.button}>
+              <Button onPress={() => {
+                const path = RNFS.MainBundlePath + "\\Assets\\pdf\\Business Report.pdf";
+                PSPDFKit.Present(path, CONFIGURATION);
+              }} title="Reload and Enable Editing"/>
+            </View>
+          </View>
+          <Image
+            source={require("./assets/logo-flat.png")}
+            style={styles.logo}
+          />
+          <Text style={styles.version}>
+            SDK Version : {PSPDFKit.versionString}
+          </Text>
+        </View>
+      </View>
+    );
+  }
 }
 
 class PdfViewStyleScreen extends Component<{}> {
@@ -578,9 +578,9 @@ export default StackNavigator(
     },
     PdfViewToolbarCustomization: {
       screen: PdfViewToolbarCustomizationScreen
-        },
+    },
     PdfViewDisableAnnotationEditing: {
-        screen: PdfViewDisableAnnotationEditingScreen
+      screen: PdfViewDisableAnnotationEditingScreen
     },
     PdfViewStyle: {
       screen: PdfViewStyleScreen

--- a/samples/Catalog/Catalog.windows.js
+++ b/samples/Catalog/Catalog.windows.js
@@ -31,6 +31,10 @@ YellowBox.ignoreWarnings([
   "Warning: Failed prop type: Invalid prop `accessibilityStates[0]`"
 ]);
 
+const CONFIGURATION = {
+    // Settings this to false will disable all annotation editing
+    enableAnnotationEditing: true
+};
 
 const complexSearchConfiguration = {
   searchString: "the",
@@ -101,7 +105,7 @@ const examples = [
       // Present can only take files loaded in the Visual studio Project's Assets. Please use RNFS.
       // See https://docs.microsoft.com/en-us/windows/uwp/files/file-access-permissions
       const path = RNFS.MainBundlePath + "\\Assets\\pdf\\Business Report.pdf";
-      PSPDFKit.Present(path)
+        PSPDFKit.Present(path, {})
         .then(() => {
           alert("File Opened successfully");
         })
@@ -162,11 +166,19 @@ const examples = [
     name: "Customize the toolbar",
     description: "An example to show how to customize the toolbar UI.",
     action: async component => {
-      component.props.navigation.navigate("PdfViewToolbarCustomization");
+      component.props.navigation.navigate("PdfViewDisableAnnotationEditing");
     }
-  },
+    },
+    {
+        key: "item8",
+        name: "Disable Annotation Editing",
+        description: "An example to show how to globally disable annotation editing.",
+        action: async component => {
+            component.props.navigation.navigate("PdfViewDisableAnnotationEditing");
+        }
+    },
   {
-    key: "item8",
+    key: "item9",
     name: "Custom colors",
     description: "Explains how to theme your UWP react native application.",
     action: component => {
@@ -306,8 +318,8 @@ class PdfViewScreen extends Component<{}> {
           ref="pdfView"
           style={styles.pdfView}
           // The default file to open.
-          document="ms-appx:///Assets/pdf/annualReport.pdf"
-        />
+            document="ms-appx:///Assets/pdf/annualReport.pdf"
+                />
         <View style={styles.footer}>
           <View style={styles.button}>
             <Button onPress={() => PSPDFKit.OpenFilePicker()} title="Open"/>
@@ -485,6 +497,39 @@ class PdfViewToolbarCustomizationScreen extends Component<{}> {
   }
 }
 
+class PdfViewDisableAnnotationEditingScreen extends Component<{}> {
+    render() {
+        return (
+        <View style={styles.page}>
+            <PSPDFKitView
+                    ref="pdfView"
+                    style={styles.pdfView}
+                    // The default file to open.
+                    document="ms-appx:///Assets/pdf/annualReport.pdf"
+                    configuration={{ enableAnnotationEditing: false}}
+                />
+    <View style={styles.footer}>
+<View style={styles.buttonRow}>
+    <View style={styles.button}>
+                            <Button onPress={() => {
+    const path = RNFS.MainBundlePath + "\\Assets\\pdf\\Business Report.pdf";
+    PSPDFKit.Present(path, CONFIGURATION);
+}} title="Reload and Enable Editing" />
+    </View> 
+    </View>
+    <Image
+source={require("./assets/logo-flat.png")}
+style={styles.logo}
+    />
+    <Text style={styles.version}>
+    SDK Version : {PSPDFKit.versionString}
+</Text>
+    </View>
+    </View>
+);
+}
+}
+
 class PdfViewStyleScreen extends Component<{}> {
   render() {
     return (
@@ -533,6 +578,9 @@ export default StackNavigator(
     },
     PdfViewToolbarCustomization: {
       screen: PdfViewToolbarCustomizationScreen
+        },
+    PdfViewDisableAnnotationEditing: {
+        screen: PdfViewDisableAnnotationEditingScreen
     },
     PdfViewStyle: {
       screen: PdfViewStyleScreen

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PDFViewPage.xaml.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PDFViewPage.xaml.cs
@@ -206,6 +206,11 @@ namespace ReactNativePSPDFKit
             _annotationCreatorName = annotationAuthorName;
         }
 
+        public void SetReadOnly(bool readOnly)
+        {
+            PdfView.ReadOnly = readOnly;
+        }
+
         private void PDFView_InitializationCompletedHandlerAsync(PdfView sender, Document document)
         {
             _pdfViewInitialized = true;

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitModule.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitModule.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
 using Windows.Storage;
+using Newtonsoft.Json.Linq;
 
 namespace ReactNativePSPDFKit
 {
@@ -56,7 +57,7 @@ namespace ReactNativePSPDFKit
         /// 
         /// </summary>
         [ReactMethod]
-        public void Present(string assetPath, IPromise promise)
+        public void Present(string assetPath, JObject configuration, IPromise promise)
         {
             DispatcherHelpers.RunOnDispatcher(async () =>
             {
@@ -65,6 +66,15 @@ namespace ReactNativePSPDFKit
                     var file = await StorageFile.GetFileFromPathAsync(assetPath);
 
                     await LoadFileAsync(file);
+
+                    if (_viewManager != null)
+                    {
+                        _viewManager.SetConfiguration(_viewManager.PdfViewPage, configuration);
+                    }
+                    else
+                    {
+                        throw new Exception("PDFViewManager: is not ready or unavailable.");
+                    }
 
                     promise.Resolve(null);
                 }

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitViewManager.cs
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/PSPDFKitViewManager.cs
@@ -20,7 +20,7 @@ namespace ReactNativePSPDFKit
 {
     public class PSPDFKitViewManger : SimpleViewManager<PDFViewPage>
     {
-
+        /// Command to enumeration mapping.
         private const int COMMAND_ENTER_ANNOTATION_CREATION_MODE = 1;
         private const int COMMAND_EXIT_CURRENTLY_ACTIVE_MODE = 2;
         private const int COMMAND_SAVE_CURRENT_DOCUMENT = 3;
@@ -30,6 +30,9 @@ namespace ReactNativePSPDFKit
         private const int COMMAND_SET_TOOLBAR_ITEMS = 7;
         private const int COMMAND_REMOVE_ANNOTATION = 8;
         private const int COMMAND_GET_ALL_ANNOTATIONS = 9;
+
+        /// View configuration string constants
+        private const string CONFIGURATION_ENABLE_ANNOTATION_EDITING = "enableAnnotationEditing";
 
         private readonly Uri _cssResource = null;
         internal PDFViewPage PdfViewPage;
@@ -90,6 +93,14 @@ namespace ReactNativePSPDFKit
         public void SetAnnotationAuthorName(PDFViewPage view, string annotationAuthorName)
         {
             view.SetAnnotationCreatorName(annotationAuthorName);
+        }
+
+        [ReactProp("configuration")]
+        public void SetConfiguration(PDFViewPage view, JObject configuration)
+        {
+            configuration.TryGetValue(CONFIGURATION_ENABLE_ANNOTATION_EDITING, out var enableAnnotationEditingJson);
+            var enableAnnotationEditing = enableAnnotationEditingJson.Value<bool>();
+            view.SetReadOnly(!enableAnnotationEditing);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes : https://github.com/PSPDFKit/react-native/issues/258

# Details
This PR brings support for `enableAnnotationEditing`. To keep inline with android and iOS this is implemented through the `configuration` prop of `PDFView`. It can also be passed to `PSPDFKit.Present` which is an API break, but brings things inline with iOS and Android.
