### PR TITLE
Bump PSPDFKit for Android to Version 6.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 *   Contains gradle configuration constants
 */
 ext {
-    PSPDFKIT_VERSION = '6.0.2'
+    PSPDFKIT_VERSION = '6.1.0'
 }
 
 buildscript {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.26.5",
+  "version": "1.26.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.26.5",
+  "version": "1.26.6",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.26.5",
+  "version": "1.26.6",
   "private": true,
   "scripts": {
     "start": "react-native start",

--- a/samples/NativeCatalog/package.json
+++ b/samples/NativeCatalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NativeCatalog",
-  "version": "1.26.5",
+  "version": "1.26.6",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
# Details

Updates our PSPDFKit for Android dependency to 6.1.

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, `samples/Catalog/package.json`, and `samples/NativeCatalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
