### PR TITLE
Update to PSPDFKit for Android 6.1.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 *   Contains gradle configuration constants
 */
 ext {
-    PSPDFKIT_VERSION = '6.1.0'
+    PSPDFKIT_VERSION = '6.1.1'
 }
 
 buildscript {
@@ -69,8 +69,8 @@ if (demoVersion) {
 }
 
 dependencies {
-    compile("com.pspdfkit:pspdfkit:${PSPDFKIT_VERSION}") {
+    implementation("com.pspdfkit:pspdfkit:${PSPDFKIT_VERSION}") {
         exclude group: 'com.google.auto.value', module: 'auto-value'
     }
-    compile "com.facebook.react:react-native:+"
+    implementation "com.facebook.react:react-native:+"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.26.6",
+  "version": "1.26.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.26.6",
+  "version": "1.26.7",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/android/gradle.properties
+++ b/samples/Catalog/android/gradle.properties
@@ -17,8 +17,6 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-android.useDeprecatedNdk=true
-android.enableAapt2=false
 android.enableDesugar=true
 org.gradle.configureondemand=false
 org.gradle.jvmargs=-Xmx2G -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.26.6",
+  "version": "1.26.7",
   "private": true,
   "scripts": {
     "start": "react-native start",

--- a/samples/NativeCatalog/package.json
+++ b/samples/NativeCatalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NativeCatalog",
-  "version": "1.26.6",
+  "version": "1.26.7",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
# Details

- Bumps the used PSPDFKit version to 6.1.1. Resolves #341 
- Also removes warnings related to deprecated build options.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, `samples/Catalog/package.json`, and `samples/NativeCatalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
