### PR TITLE
Return a promise when calling PSPDFKit.present()

### DIFF
--- a/ios/RCTPSPDFKit/RCTPSPDFKitManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitManager.m
@@ -22,36 +22,57 @@
 
 RCT_EXPORT_MODULE(PSPDFKit)
 
-RCT_EXPORT_METHOD(setLicenseKey:(NSString *)licenseKey) {
-  [PSPDFKitGlobal setLicenseKey:licenseKey];
+RCT_REMAP_METHOD(setLicenseKey, setLicenseKey:(NSString *)licenseKey resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+  if (licenseKey.length > 0) {
+    [PSPDFKitGlobal setLicenseKey:licenseKey];
+    resolve(@(YES));
+  } else {
+    reject(@"error", @"Invalid License Key.", nil);
+  }
 }
 
-RCT_EXPORT_METHOD(present:(PSPDFDocument *)document withConfiguration:(PSPDFConfiguration *)configuration) {
+RCT_REMAP_METHOD(present, present:(PSPDFDocument *)document withConfiguration:(PSPDFConfiguration *)configuration resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   PSPDFViewController *pdfViewController = [[PSPDFViewController alloc] initWithDocument:document configuration:configuration];
-
   UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:pdfViewController];
-
   navigationController.modalPresentationStyle = UIModalPresentationFullScreen;
   UIViewController *presentingViewController = RCTPresentedViewController();
-  [presentingViewController presentViewController:navigationController animated:YES completion:nil];
+
+  if (presentingViewController) {
+    [presentingViewController presentViewController:navigationController animated:YES completion:nil];
+    resolve(@(YES));
+  } else {
+    reject(@"error", @"Failed to present document.", nil);
+  }
 }
 
-RCT_EXPORT_METHOD(dismiss) {
+RCT_REMAP_METHOD(dismiss, resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   UIViewController *presentedViewController = RCTPresentedViewController();
   NSAssert([presentedViewController isKindOfClass:UINavigationController.class], @"Presented view controller needs to be a UINavigationController");
   UINavigationController *navigationController = (UINavigationController *)presentedViewController;
   NSAssert(navigationController.viewControllers.count == 1 && [navigationController.viewControllers.firstObject isKindOfClass:PSPDFViewController.class], @"Presented view controller needs to contain a PSPDFViewController");
-  [navigationController dismissViewControllerAnimated:true completion:nil];
+
+  if (navigationController) {
+    [navigationController dismissViewControllerAnimated:true completion:nil];
+    resolve(@(YES));
+  } else {
+    reject(@"error", @"Failed to dismiss", nil);
+  }
 }
 
-RCT_EXPORT_METHOD(setPageIndex:(NSUInteger)pageIndex animated:(BOOL)animated) {
+RCT_REMAP_METHOD(setPageIndex, setPageIndex:(NSUInteger)pageIndex animated:(BOOL)animated resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   UIViewController *presentedViewController = RCTPresentedViewController();
   NSAssert([presentedViewController isKindOfClass:UINavigationController.class], @"Presented view controller needs to be a UINavigationController");
   UINavigationController *navigationController = (UINavigationController *)presentedViewController;
   NSAssert(navigationController.viewControllers.count == 1 && [navigationController.viewControllers.firstObject isKindOfClass:PSPDFViewController.class], @"Presented view controller needs to contain a PSPDFViewController");
+
   PSPDFViewController *pdfViewController = (PSPDFViewController *)navigationController.viewControllers.firstObject;
-
-  [pdfViewController setPageIndex:pageIndex animated:animated];
+  // Validate the the page index is not out of bounds.
+  if (pageIndex < pdfViewController.document.pageCount) {
+    [pdfViewController setPageIndex:pageIndex animated:animated];
+    resolve(@(YES));
+  } else {
+    reject(@"error", @"Page Index out of bounds", nil);
+  }
 }
 
 - (dispatch_queue_t)methodQueue {

--- a/ios/RCTPSPDFKit/RCTPSPDFKitManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitManager.m
@@ -38,8 +38,9 @@ RCT_REMAP_METHOD(present, present:(PSPDFDocument *)document withConfiguration:(P
   UIViewController *presentingViewController = RCTPresentedViewController();
 
   if (presentingViewController) {
-    [presentingViewController presentViewController:navigationController animated:YES completion:nil];
-    resolve(@(YES));
+    [presentingViewController presentViewController:navigationController animated:YES completion:^{
+      resolve(@(YES));
+    }];
   } else {
     reject(@"error", @"Failed to present document.", nil);
   }
@@ -52,8 +53,9 @@ RCT_REMAP_METHOD(dismiss, resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCT
   NSAssert(navigationController.viewControllers.count == 1 && [navigationController.viewControllers.firstObject isKindOfClass:PSPDFViewController.class], @"Presented view controller needs to contain a PSPDFViewController");
 
   if (navigationController) {
-    [navigationController dismissViewControllerAnimated:true completion:nil];
-    resolve(@(YES));
+    [navigationController dismissViewControllerAnimated:true completion:^{
+      resolve(@(YES));
+    }];
   } else {
     reject(@"error", @"Failed to dismiss", nil);
   }
@@ -71,7 +73,7 @@ RCT_REMAP_METHOD(setPageIndex, setPageIndex:(NSUInteger)pageIndex animated:(BOOL
     [pdfViewController setPageIndex:pageIndex animated:animated];
     resolve(@(YES));
   } else {
-    reject(@"error", @"Page Index out of bounds", nil);
+    reject(@"error", @"Failed to set page index: The page index is out of bounds", nil);
   }
 }
 

--- a/ios/RCTPSPDFKit/RCTPSPDFKitManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitManager.m
@@ -53,7 +53,7 @@ RCT_REMAP_METHOD(dismiss, resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCT
   NSAssert(navigationController.viewControllers.count == 1 && [navigationController.viewControllers.firstObject isKindOfClass:PSPDFViewController.class], @"Presented view controller needs to contain a PSPDFViewController");
 
   if (navigationController) {
-    [navigationController dismissViewControllerAnimated:true completion:^{
+    [navigationController dismissViewControllerAnimated:YES completion:^{
       resolve(@(YES));
     }];
   } else {

--- a/samples/Catalog/Catalog.android.js
+++ b/samples/Catalog/Catalog.android.js
@@ -59,7 +59,12 @@ const examples = [
     name: "Open assets document",
     description: "Open document from your project assets folder",
     action: () => {
-      PSPDFKit.present("file:///android_asset/Annual Report.pdf", {});
+      PSPDFKit.present("file:///android_asset/Annual Report.pdf", {})
+        .then(loaded => {
+          console.log("Document was loaded successfully.")
+        }).catch(error => {
+          console.log(error);
+        });
       PSPDFKit.setPageIndex(3, false);
     }
   },

--- a/samples/Catalog/Catalog.ios.js
+++ b/samples/Catalog/Catalog.ios.js
@@ -26,7 +26,13 @@ const RNFS = require("react-native-fs");
 import PSPDFKitView from "react-native-pspdfkit";
 const PSPDFKit = NativeModules.PSPDFKit;
 
-PSPDFKit.setLicenseKey("YOUR_LICENSE_KEY_GOES_HERE");
+PSPDFKit.setLicenseKey("YOUR_LICENSE_KEY_GOES_HERE").then(result => {
+  if (result) {
+    console.log("Successfully set the license key.");
+  } else {
+    console.log(error);
+  }
+});
 
 const pspdfkitColor = "#267AD4";
 const pspdfkitColorAlpha = "#267AD450";
@@ -37,7 +43,13 @@ const examples = [
     name: "Open document using resource path",
     description: "Open document from your resource bundle with relative path.",
     action: () => {
-      PSPDFKit.present("PDFs/Annual Report.pdf", {});
+      PSPDFKit.present("PDFs/Annual Report.pdf", {}).then(result => {
+        if (result) {
+          console.log("Successfully presented document.");
+        } else {
+          console.log(error);
+        }
+      });
     }
   },
   {
@@ -58,8 +70,20 @@ const examples = [
           }
         })
         .then(() => {
-          PSPDFKit.present(path, {});
-          PSPDFKit.setPageIndex(3, false);
+          PSPDFKit.present(path, {}).then(result => {
+            if (result) {
+              console.log("Successfully presented document.");
+            } else {
+              console.log(error);
+            }
+          });
+          PSPDFKit.setPageIndex(3, false).then(result => {
+            if (result) {
+              console.log("Successfully set the page index.");
+            } else {
+              console.log(error);
+            }
+          });
         })
         .catch(err => {
           console.log(err.message, err.code);
@@ -80,6 +104,12 @@ const examples = [
         showPageLabels: false,
         showDocumentLabel: true,
         inlineSearch: true
+      }).then(result => {
+        if (result) {
+          console.log("Successfully presented document.");
+        } else {
+          console.log(error);
+        }
       });
     }
   },


### PR DESCRIPTION
## Resolves #243 

# Details

Calling `present()` now returns a promise that either resolves to `true` or provides the exception that occurred when loading the document.

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, `samples/Catalog/package.json`, and `samples/NativeCatalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
