### PR TITLE
Include uuid in annotation removed event

### DIFF
--- a/android/src/main/java/com/pspdfkit/react/events/PdfViewAnnotationChangedEvent.java
+++ b/android/src/main/java/com/pspdfkit/react/events/PdfViewAnnotationChangedEvent.java
@@ -57,6 +57,7 @@ public class PdfViewAnnotationChangedEvent extends Event<PdfViewAnnotationChange
                 annotationMap = new HashMap<>();
                 annotationMap.put("name", annotation.getName());
                 annotationMap.put("creatorName", annotation.getCreator());
+                annotationMap.put("uuid", annotation.getUuid());
             } else {
                 JSONObject instantJson = new JSONObject(annotation.toInstantJson());
                 annotationMap = JsonUtilities.jsonObjectToMap(instantJson);

--- a/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFAnnotation.m
+++ b/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFAnnotation.m
@@ -24,7 +24,7 @@
       }
     } else {
       // We only generate Instant JSON data for attached annotations. When an annotation is deleted, we only set the annotation uuid and name.
-      [annotationsJSON addObject:@{@"uuid" : annotation.uuid, @"name" : annotation.name ?: [NSNull null]}];
+      [annotationsJSON addObject:@{@"uuid" : annotation.uuid, @"name" : annotation.name ?: [NSNull null], @"creatorName" : annotation.user ?: [NSNull null]}];
     }
   }
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.27.2",
+  "version": "1.27.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.27.2",
+  "version": "1.27.3",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.27.2",
+  "version": "1.27.3",
   "private": true,
   "scripts": {
     "start": "react-native start",

--- a/samples/NativeCatalog/package.json
+++ b/samples/NativeCatalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NativeCatalog",
-  "version": "1.27.2",
+  "version": "1.27.3",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
## For #283 

# Details

- Includes the `uuid` in the removed event.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, `samples/Catalog/package.json`, and `samples/NativeCatalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
