### PR TITLE
Put PSPDFKit on Gradle's 'api' configuration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -69,7 +69,7 @@ if (demoVersion) {
 }
 
 dependencies {
-    implementation("com.pspdfkit:pspdfkit:${PSPDFKIT_VERSION}") {
+    api("com.pspdfkit:pspdfkit:${PSPDFKIT_VERSION}") {
         exclude group: 'com.google.auto.value', module: 'auto-value'
     }
     implementation "com.facebook.react:react-native:+"


### PR DESCRIPTION
This allows users to use PSPDFKit classes in their app's native extension sources as it was possible when we still used the compile configuration.

# Details

With our update to PSPDFKit 6.1.1 we changed the source configuration used for PSPDFKit from `compile` (which is deprecated) to `implementation`. This had the side-effect that PSPDFKit Java classes would no longer be available in apps that used native Java code. Putting the dependency on the `api` configuration fixes this issue.

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, `samples/Catalog/package.json`, and `samples/NativeCatalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
