### PR TITLE
Reload the entire document when calling `addAnnotations`

### DIFF
--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -285,7 +285,7 @@
     NSLog(@"Failed to add annotations.");
   }
   
-  [self.pdfController reloadPageAtIndex:self.pdfController.pageIndex animated:NO];
+  [self.pdfController reloadData];
   return success;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.28.2",
+  "version": "1.28.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.28.2",
+  "version": "1.28.3",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.28.2",
+  "version": "1.28.3",
   "private": true,
   "scripts": {
     "start": "react-native start",

--- a/samples/NativeCatalog/package.json
+++ b/samples/NativeCatalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NativeCatalog",
-  "version": "1.28.2",
+  "version": "1.28.3",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
# Details

Before we were only reloading the current visible page when calling `addAnnotations`. We were making assumptions that users add annotations to the currently displayed page. This can be perceived as a bug (see Z#17956).

## How to Reproduce in the Catalog app:

- Launch the Catalog app and open the Programmatic Annotations example.
- Scroll to the second page.
- Tap on the `addAnnotations` button.
- Scroll back to the first page.

## Expected:

The added annotations should be visible.

## Actual:

The added annotations are not visible.

![recording](https://user-images.githubusercontent.com/7443038/76701190-401ca200-6695-11ea-830e-d6b94bbe5a59.gif)

# Acceptance Criteria

- [x] The entire PSPDFViewController is reloaded when using `addAnnotations`.
- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, `samples/Catalog/package.json`, and `samples/NativeCatalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
