### PR TITLE
Add support for hiding the main toolbar

### DIFF
--- a/android/src/main/java/com/pspdfkit/react/ReactPdfViewManager.java
+++ b/android/src/main/java/com/pspdfkit/react/ReactPdfViewManager.java
@@ -153,6 +153,11 @@ public class ReactPdfViewManager extends ViewGroupManager<PdfView> {
         view.setShowNavigationButtonInToolbar(showNavigationButtonInToolbar);
     }
 
+    @ReactProp(name= "hideDefaultToolbar")
+    public void setHideDefaultToolbar(@NonNull final PdfView view,final boolean hideDefaultToolbar) {
+        view.setHideDefaultToolbar(hideDefaultToolbar);
+    }
+
     @Nullable
     @Override
     public Map getExportedCustomDirectEventTypeConstants() {

--- a/android/src/main/java/com/pspdfkit/views/ReactMainToolbar.java
+++ b/android/src/main/java/com/pspdfkit/views/ReactMainToolbar.java
@@ -1,0 +1,48 @@
+package com.pspdfkit.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.pspdfkit.ui.toolbar.MainToolbar;
+
+/** Custom toolbar that allows us to force a visibility. */
+public class ReactMainToolbar extends MainToolbar {
+
+    private @Nullable Integer forcedVisibility;
+
+    public ReactMainToolbar(@NonNull Context context) {
+        super(context);
+    }
+
+    public ReactMainToolbar(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public ReactMainToolbar(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    /**
+     * Sets a forced visibility that will override all future calls to {@link #setVisibility(int)}. The visibility will also immediately be applied.
+     *
+     * @param visibility The visibility to force or {@code null} to not force any specific visibility.
+     */
+    public void setForcedVisibility(@Nullable final Integer visibility) {
+        forcedVisibility = visibility;
+        if (forcedVisibility != null) {
+            setVisibility(forcedVisibility);
+        }
+    }
+
+    @Override
+    public void setVisibility(int visibility) {
+        if (forcedVisibility == null) {
+            super.setVisibility(visibility);
+        } else {
+            super.setVisibility(forcedVisibility);
+        }
+    }
+}

--- a/android/src/main/java/com/pspdfkit/views/ReactPdfUiFragment.java
+++ b/android/src/main/java/com/pspdfkit/views/ReactPdfUiFragment.java
@@ -33,7 +33,6 @@ public class ReactPdfUiFragment extends PdfUiFragment {
         }
     }
 
-
     /** When set to true will add a navigation arrow to the toolbar. */
     void setShowNavigationButtonInToolbar(final boolean showNavigationButtonInToolbar) {
         if (getView() == null) {

--- a/android/src/main/res/layout/pspdf__toolbar_main.xml
+++ b/android/src/main/res/layout/pspdf__toolbar_main.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ pspdf__toolbar_main.xml
+  ~
+  ~   PSPDFKit
+  ~
+  ~   Copyright © 2014-2020 PSPDFKit GmbH. All rights reserved.
+  ~
+  ~   THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY INTERNATIONAL COPYRIGHT LAW
+  ~   AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT.
+  ~   UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
+  ~   This notice may not be removed from this file.
+  -->
+
+<com.pspdfkit.views.ReactMainToolbar xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/pspdf__toolbar_main"
+    android:layout_width="match_parent"
+    android:layout_height="?attr/actionBarSize"
+    android:elevation="@dimen/pspdf__toolbar_elevation"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
+    app:contentInsetEnd="16dp"
+    app:contentInsetRight="16dp"
+    tools:ignore="Overdraw,UnusedAttribute" />

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -118,7 +118,7 @@
 
 - (BOOL)enterAnnotationCreationMode {
   [self.pdfController setViewMode:PSPDFViewModeDocument animated:YES];
-  [self.pdfController.annotationToolbarController updateHostView:nil container:nil viewController:self.pdfController];
+  [self.pdfController.annotationToolbarController updateHostView:self container:nil viewController:self.pdfController];
   return [self.pdfController.annotationToolbarController showToolbarAnimated:YES completion:NULL];
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.28.5",
+  "version": "1.28.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.28.5",
+  "version": "1.28.6",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/Catalog.android.js
+++ b/samples/Catalog/Catalog.android.js
@@ -50,7 +50,7 @@ const CONFIGURATION = {
   // Settings this to false will disable all annotation editing
   enableAnnotationEditing: true,
   // Only stamps and square annotations will be editable, others can not be selected or otherwise modified.
-  editableAnnotationTypes: ['Stamp', 'Square']
+  editableAnnotationTypes: ["Stamp", "Square"]
 };
 
 const examples = [
@@ -61,8 +61,9 @@ const examples = [
     action: () => {
       PSPDFKit.present("file:///android_asset/Annual Report.pdf", {})
         .then(loaded => {
-          console.log("Document was loaded successfully.")
-        }).catch(error => {
+          console.log("Document was loaded successfully.");
+        })
+        .catch(error => {
           console.log(error);
         });
       PSPDFKit.setPageIndex(3, false);
@@ -164,6 +165,17 @@ const examples = [
     action: component => {
       extractFromAssetsIfMissing("Annual Report.pdf", function() {
         component.props.navigation.push("AnnotationProcessing");
+      });
+    }
+  },
+  {
+    key: "item13",
+    name: "Hiding Toolbar",
+    description:
+      "Shows how to hide the main toolbar while keeping the thumbnail bar visible.",
+    action: component => {
+      extractFromAssetsIfMissing("Annual Report.pdf", function() {
+        component.props.navigation.push("HidingToolbar");
       });
     }
   }
@@ -289,7 +301,7 @@ class PdfViewScreen extends Component<{}> {
 
     return {
       // Since the PSPDFKitView provides it's own toolbar and back button we don't need a header.
-      header: null,
+      header: null
     };
   };
 
@@ -342,7 +354,7 @@ class PdfViewScreen extends Component<{}> {
           fragmentTag="PDF1"
           showNavigationButtonInToolbar={true}
           onNavigationButtonClicked={event => {
-            this.props.navigation.goBack()
+            this.props.navigation.goBack();
           }}
           menuItemGrouping={[
             "freetext",
@@ -569,7 +581,10 @@ class PdfViewInstantJsonScreen extends Component<{}> {
                     lineWidth: 5,
                     name: "my annotation",
                     lines: {
-                      intensities: [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5]],
+                      intensities: [
+                        [0.5, 0.5, 0.5],
+                        [0.5, 0.5, 0.5]
+                      ],
                       points: [
                         [
                           [92.08633422851562, 101.07916259765625],
@@ -960,6 +975,74 @@ class AnnotationProcessing extends Component {
   }
 }
 
+class HidingToolbar extends Component {
+  static navigationOptions = ({ navigation }) => {
+    const params = navigation.state.params || {};
+    return {
+      title: "Hidden Toolbar",
+      headerRight: (
+        <Button
+          onPress={() => params.handleAnnotationButtonPress()}
+          title="Annotations"
+        />
+      )
+    };
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      annotationCreationActive: false,
+      annotationEditingActive: false
+    };
+  }
+
+  componentDidMount() {
+    this.props.navigation.setParams({
+      handleAnnotationButtonPress: () => {
+        if (
+          this.state.annotationCreationActive ||
+          this.state.annotationEditingActive
+        ) {
+          this.refs.pdfView.exitCurrentlyActiveMode();
+        } else {
+          this.refs.pdfView.enterAnnotationCreationMode();
+        }
+      }
+    });
+  }
+
+  render() {
+    return (
+      <View style={{ flex: 1 }}>
+        <PSPDFKitView
+          ref="pdfView"
+          document={DOCUMENT}
+          configuration={{
+            backgroundColor: processColor("lightgrey"),
+            showThumbnailBar: "scrollable",
+            // If you want to hide the toolbar it's essential to also hide the document label overlay.
+            documentLabelEnabled: false,
+            // We want to keep the thumbnail bar always visible, but the automatic mode is also supported with hideDefaultToolbar.
+            userInterfaceViewMode: "alwaysVisible"
+          }}
+          // This will just hide the toolbar, keeping the thumbnail bar visible.
+          hideDefaultToolbar={true}
+          disableAutomaticSaving={true}
+          fragmentTag="PDF1"
+          onStateChanged={event => {
+            this.setState({
+              annotationCreationActive: event.annotationCreationActive,
+              annotationEditingActive: event.annotationEditingActive
+            });
+          }}
+          style={{ flex: 1, color: pspdfkitColor }}
+        />
+      </View>
+    );
+  }
+}
+
 export default createAppContainer(
   createStackNavigator(
     {
@@ -983,6 +1066,9 @@ export default createAppContainer(
       },
       AnnotationProcessing: {
         screen: AnnotationProcessing
+      },
+      HidingToolbar: {
+        screen: HidingToolbar
       }
     },
     {

--- a/samples/Catalog/Catalog.ios.js
+++ b/samples/Catalog/Catalog.ios.js
@@ -226,6 +226,15 @@ const examples = [
     action: component => {
       component.props.navigation.push("AnnotationProcessing");
     }
+  },
+  {
+    key: "item16",
+    name: "Hiding Toolbar",
+    description:
+      "Shows how to hide the main toolbar while keeping the thumbnail bar visible.",
+    action: component => {
+      component.props.navigation.push("HidingToolbar");
+    }
   }
 ];
 
@@ -1289,6 +1298,75 @@ class ToolbarCustomization extends Component {
   }
 }
 
+class HidingToolbar extends Component {
+  static navigationOptions = ({ navigation }) => {
+    const params = navigation.state.params || {};
+    return {
+      title: "Hidden Toolbar",
+      headerRight: (
+        <Button
+          onPress={() => params.handleAnnotationButtonPress()}
+          title="Annotations"
+        />
+      )
+    };
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      annotationCreationActive: false,
+      annotationEditingActive: false
+    };
+  }
+
+  componentDidMount() {
+    this.props.navigation.setParams({
+      handleAnnotationButtonPress: () => {
+        if (
+          this.state.annotationCreationActive ||
+          this.state.annotationEditingActive
+        ) {
+          this.refs.pdfView.exitCurrentlyActiveMode();
+        } else {
+          this.refs.pdfView.enterAnnotationCreationMode();
+        }
+      }
+    });
+  }
+
+  render() {
+    return (
+      <View style={{ flex: 1 }}>
+        <PSPDFKitView
+          ref="pdfView"
+		  document={"PDFs/Annual Report.pdf"}
+          configuration={{
+            backgroundColor: processColor("lightgrey"),
+            showThumbnailBar: "scrollable",
+            // If you want to hide the toolbar it's essential to also hide the document label overlay.
+            documentLabelEnabled: false,
+            // We want to keep the thumbnail bar always visible, but the automatic mode is also supported with hideDefaultToolbar.
+            userInterfaceViewMode: "alwaysVisible",
+            useParentNavigationBar: true
+          }}
+          // This will just hide the toolbar, keeping the thumbnail bar visible.
+          //hideDefaultToolbar={true}
+          disableAutomaticSaving={true}
+          fragmentTag="PDF1"
+          onStateChanged={event => {
+            this.setState({
+              annotationCreationActive: event.annotationCreationActive,
+              annotationEditingActive: event.annotationEditingActive
+            });
+          }}
+          style={{ flex: 1, color: pspdfkitColor }}
+        />
+      </View>
+    );
+  }
+}
+
 class Catalog extends Component<{}> {
   static navigationOptions = {
     title: "Catalog"
@@ -1381,6 +1459,9 @@ export default createAppContainer(
       },
       AnnotationProcessing: {
         screen: AnnotationProcessing
+      },
+      HidingToolbar: {
+        screen: HidingToolbar
       }
     },
     {

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.28.5",
+  "version": "1.28.6",
   "private": true,
   "scripts": {
     "start": "react-native start",

--- a/samples/NativeCatalog/App.js
+++ b/samples/NativeCatalog/App.js
@@ -6,6 +6,7 @@ import {
   View,
   NativeModules,
   Button,
+  Text,
   requireNativeComponent,
 } from 'react-native';
 import {createStackNavigator, createAppContainer} from 'react-navigation';
@@ -69,6 +70,22 @@ const examples = [
         });
       } else {
         component.props.navigation.navigate('WatermarkStartup');
+      }
+    },
+  },
+  {
+    name: 'Default Annotation Settings',
+    description:
+      'Shows how to configure default annotations settings. (Android Only)',
+    action: component => {
+      if (Platform.OS === 'android') {
+        requestExternalStoragePermission(function() {
+          extractFromAssetsIfMissing('Form_example.pdf', function() {
+            component.props.navigation.navigate('DefaultAnnotationSettings');
+          });
+        });
+      } else {
+        component.props.navigation.navigate('DefaultAnnotationSettings');
       }
     },
   },
@@ -154,7 +171,7 @@ class WatermarkScreen extends Component<{}> {
           <View>
             <Button
               onPress={() => {
-                 // This will create a watermark in native code.
+                // This will create a watermark in native code.
                 if (Platform.OS === 'android') {
                   UIManager.dispatchViewManagerCommand(
                     findNodeHandle(this.refs.pdfView),
@@ -203,6 +220,30 @@ class WatermarkStartupScreen extends Component<{}> {
   }
 }
 
+class DefaultAnnotationSettingsScreen extends Component<{}> {
+  render() {
+    return (
+      <View style={{flex: 1}}>
+        {Platform.OS === 'android' && (
+          <CustomPdfView
+            ref="pdfView"
+            document={FORM_DOCUMENT}
+            style={{flex: 1}}
+            // This way only the ink tool and the button to open the inspector is show.
+            // If you don't need the inspector you can remove the "picker" option completely
+            // and only configure the tool using the AnnotationConfiguration.
+            // See CustomPdfViewManager#setDocument() for how to apply the custom configuration.
+            menuItemGrouping={['pen', 'picker']}
+          />
+        )}
+        {Platform.OS === 'ios' && (
+          <Text>This example isn't supported on iOS!</Text>
+        )}
+      </View>
+    );
+  }
+}
+
 export default createAppContainer(
   createStackNavigator(
     {
@@ -217,6 +258,9 @@ export default createAppContainer(
       },
       WatermarkStartup: {
         screen: WatermarkStartupScreen,
+      },
+      DefaultAnnotationSettings: {
+        screen: DefaultAnnotationSettingsScreen,
       },
     },
     {

--- a/samples/NativeCatalog/package.json
+++ b/samples/NativeCatalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NativeCatalog",
-  "version": "1.28.5",
+  "version": "1.28.6",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
# Details

- Adds support for hiding the main toolbar using the new `hideDefaultToolbar` prop. This allows for the old behaviour where the thumbnail bar was shown but the main toolbar wasn't.
- Adds new "Hiding Toolbar" sample to Catalog app.
- Adds new "Default Annotation Setting" sample to Native Catalog app to show how to configure annotation defaults.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, `samples/Catalog/package.json`, and `samples/NativeCatalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
