### PR TITLE
Bridge Instant Example from PSPDFKit Catalog to the NativeCatalog React Native project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "private": true,
   "scripts": {
     "start": "react-native start",

--- a/samples/NativeCatalog/App.js
+++ b/samples/NativeCatalog/App.js
@@ -29,10 +29,10 @@ const examples = [
     name: 'Manual Signing',
     description:
       'Shows how to start the signing flow using a react-native button linked to our CustomPdfView.',
-    action: component => {
+    action: (component) => {
       if (Platform.OS === 'android') {
-        requestExternalStoragePermission(function() {
-          extractFromAssetsIfMissing('Form_example.pdf', function() {
+        requestExternalStoragePermission(function () {
+          extractFromAssetsIfMissing('Form_example.pdf', function () {
             component.props.navigation.navigate('ManualSigning');
           });
         });
@@ -45,10 +45,10 @@ const examples = [
     name: 'Watermark',
     description:
       'Shows how to watermark a PDF that is loaded in our CustomPdfView',
-    action: component => {
+    action: (component) => {
       if (Platform.OS === 'android') {
-        requestExternalStoragePermission(function() {
-          extractFromAssetsIfMissing('Form_example.pdf', function() {
+        requestExternalStoragePermission(function () {
+          extractFromAssetsIfMissing('Form_example.pdf', function () {
             component.props.navigation.navigate('Watermark');
           });
         });
@@ -61,10 +61,10 @@ const examples = [
     name: 'Watermark on Startup',
     description:
       'Shows how to watermark a PDF as soon as it is loaded in our CustomPdfView',
-    action: component => {
+    action: (component) => {
       if (Platform.OS === 'android') {
-        requestExternalStoragePermission(function() {
-          extractFromAssetsIfMissing('Form_example.pdf', function() {
+        requestExternalStoragePermission(function () {
+          extractFromAssetsIfMissing('Form_example.pdf', function () {
             component.props.navigation.navigate('WatermarkStartup');
           });
         });
@@ -77,15 +77,24 @@ const examples = [
     name: 'Default Annotation Settings',
     description:
       'Shows how to configure default annotations settings. (Android Only)',
-    action: component => {
+    action: (component) => {
       if (Platform.OS === 'android') {
-        requestExternalStoragePermission(function() {
-          extractFromAssetsIfMissing('Form_example.pdf', function() {
+        requestExternalStoragePermission(function () {
+          extractFromAssetsIfMissing('Form_example.pdf', function () {
             component.props.navigation.navigate('DefaultAnnotationSettings');
           });
         });
       } else {
         component.props.navigation.navigate('DefaultAnnotationSettings');
+      }
+    },
+  },
+  {
+    name: 'Instant Example',
+    description: 'Shows the Native Swift Instant Example. (iOS only)',
+    action: (component) => {
+      if (Platform.OS === 'ios') {
+        component.props.navigation.push('InstantExample');
       }
     },
   },
@@ -106,7 +115,7 @@ class ManualSigningScreen extends Component<{}> {
           ref="pdfView"
           document={this.state.documentPath}
           style={{flex: 1}}
-          onDocumentDigitallySigned={event => {
+          onDocumentDigitallySigned={(event) => {
             this.setState({
               documentPath: event.nativeEvent.signedDocumentPath,
             });
@@ -157,7 +166,7 @@ class WatermarkScreen extends Component<{}> {
           ref="pdfView"
           document={this.state.documentPath}
           style={{flex: 1}}
-          onDocumentWatermarked={event => {
+          onDocumentWatermarked={(event) => {
             this.setState({
               documentPath: event.nativeEvent.watermarkedDocumentPath,
             });
@@ -209,12 +218,35 @@ class WatermarkStartupScreen extends Component<{}> {
           ref="pdfView"
           document={this.state.documentPath}
           style={{flex: 1}}
-          onDocumentWatermarked={event => {
+          onDocumentWatermarked={(event) => {
             this.setState({
               documentPath: event.nativeEvent.watermarkedDocumentPath,
             });
           }}
         />
+      </View>
+    );
+  }
+}
+
+class InstantExampleScreen extends Component<{}> {
+  render() {
+    return (
+      <View style={{flex: 1}}>
+        {Platform.OS === 'ios' && <CustomPdfView ref="pdfView" />}
+        {Platform.OS === 'ios' && (
+          <Button
+            onPress={() => {
+              NativeModules.CustomPdfViewManager.presentInstantExample(
+                findNodeHandle(this.refs.pdfView),
+              );
+            }}
+            title="Present Instant Example"
+          />
+        )}
+        {Platform.OS === 'android' && (
+          <Text>This example isn't supported on Android!</Text>
+        )}
       </View>
     );
   }
@@ -258,6 +290,9 @@ export default createAppContainer(
       },
       WatermarkStartup: {
         screen: WatermarkStartupScreen,
+      },
+      InstantExample: {
+        screen: InstantExampleScreen,
       },
       DefaultAnnotationSettings: {
         screen: DefaultAnnotationSettingsScreen,

--- a/samples/NativeCatalog/README.md
+++ b/samples/NativeCatalog/README.md
@@ -61,6 +61,8 @@ target 'YourApp' do
   pod 'react-native-pspdfkit', :path => '../node_modules/react-native-pspdfkit'
 - pod 'PSPDFKit', podspec: 'https://customers.pspdfkit.com/cocoapods/YOUR_COCOAPODS_KEY_GOES_HERE/pspdfkit/latest.podspec'
 + pod 'PSPDFKit', podspec: 'https://customers.pspdfkit.com/cocoapods/USE_YOUR_OWN_COCOAPODS_KEY/pspdfkit/latest.podspec'
+- pod 'Instant', podspec:'https://customers.pspdfkit.com/cocoapods/YOUR_COCOAPODS_KEY_GOES_HERE/instant/latest.podspec'
++ pod 'Instant', podspec:'https://customers.pspdfkit.com/cocoapods/USE_YOUR_OWN_COCOAPODS_KEY/instant/latest.podspec'
 
   use_native_modules!
 end

--- a/samples/NativeCatalog/ios/InstantExample/InstantDocumentInfo.swift
+++ b/samples/NativeCatalog/ios/InstantExample/InstantDocumentInfo.swift
@@ -29,28 +29,13 @@ extension InstantDocumentInfo {
     }
 
     init?(json: Any) {
-        guard let dictionary = json as? [String: Any] else {
-            return nil
-        }
-
-        guard let serverUrlString = dictionary[JSONKeys.serverUrl.rawValue] as? String else {
-            return nil
-        }
-
-        guard let serverURL = URL(string: serverUrlString) else {
-            return nil
-        }
-
-        guard let urlString = dictionary[JSONKeys.url.rawValue] as? String else {
-            return nil
-        }
-
-        guard let url = URL(string: urlString) else {
-            return nil
-        }
-
-        guard let jwt = dictionary[JSONKeys.jwt.rawValue] as? String else {
-            return nil
+        guard let dictionary = json as? [String: Any],
+            let serverUrlString = dictionary[JSONKeys.serverUrl.rawValue] as? String,
+            let serverURL = URL(string: serverUrlString),
+            let urlString = dictionary[JSONKeys.url.rawValue] as? String,
+            let url = URL(string: urlString),
+            let jwt = dictionary[JSONKeys.jwt.rawValue] as? String else {
+                return nil
         }
 
         self.init(serverURL: serverURL, url: url, jwt: jwt)

--- a/samples/NativeCatalog/ios/InstantExample/InstantDocumentInfo.swift
+++ b/samples/NativeCatalog/ios/InstantExample/InstantDocumentInfo.swift
@@ -1,0 +1,58 @@
+//
+//  InstantDocumentInfo.swift
+//  PSPDFKit
+//
+//  Copyright © 2017-2020 PSPDFKit GmbH. All rights reserved.
+//
+//  THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY INTERNATIONAL COPYRIGHT LAW
+//  AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT.
+//  UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
+//  This notice may not be removed from this file.
+//
+
+/// The response from the PSPDFKit for Web examples server API that may be used to load a document layer with Instant.
+struct InstantDocumentInfo {
+    let serverURL: URL
+    let url: URL
+    let jwt: String
+}
+
+extension InstantDocumentInfo: Equatable {
+    public static func == (lhs: InstantDocumentInfo, rhs: InstantDocumentInfo) -> Bool {
+        return lhs.serverURL == rhs.serverURL && lhs.url == rhs.url && lhs.jwt == rhs.jwt
+    }
+}
+
+extension InstantDocumentInfo {
+    enum JSONKeys: String {
+        case serverUrl, url, documentId, jwt
+    }
+
+    init?(json: Any) {
+        guard let dictionary = json as? [String: Any] else {
+            return nil
+        }
+
+        guard let serverUrlString = dictionary[JSONKeys.serverUrl.rawValue] as? String else {
+            return nil
+        }
+
+        guard let serverURL = URL(string: serverUrlString) else {
+            return nil
+        }
+
+        guard let urlString = dictionary[JSONKeys.url.rawValue] as? String else {
+            return nil
+        }
+
+        guard let url = URL(string: urlString) else {
+            return nil
+        }
+
+        guard let jwt = dictionary[JSONKeys.jwt.rawValue] as? String else {
+            return nil
+        }
+
+        self.init(serverURL: serverURL, url: url, jwt: jwt)
+    }
+}

--- a/samples/NativeCatalog/ios/InstantExample/InstantDocumentPresenter.swift
+++ b/samples/NativeCatalog/ios/InstantExample/InstantDocumentPresenter.swift
@@ -13,23 +13,23 @@ import PSPDFKitUI
  Connects to our public PSPDFKit for Web examples server to present documents managed by PSPDFKit Instant.
  This is decoupled from any view controller in order to support loading documents by opening URLs.
  */
-class InstantDocumentPresenter {
+public class InstantDocumentPresenter {
     /**
      Interfaces with our Web examples server to create and access documents.
      In your own app you would connect to your own server backend to get Instant document identifiers and authentication tokens.
      */
-    private lazy var apiClient = WebPreviewAPIClient(presentingViewController: presentingViewController)
+    private lazy var apiClient = WebExamplesAPIClient(presentingViewController: presentingViewController)
 
     /// View controller that can present other view controllers.
     private weak var presentingViewController: UIViewController?
 
     /// Initialize a document presenter with a view controller that can present other view controllers.
-    init(presentingViewController: UIViewController) {
+    public init(presentingViewController: UIViewController) {
         self.presentingViewController = presentingViewController
     }
 
     /// Tries to create a new Instant session.
-    func createNewSession() {
+    public func createNewSession() {
         loadSession(loadingMessage: "Creating") { completion in
             self.apiClient.createNewSession(completion: completion)
         }
@@ -40,7 +40,7 @@ class InstantDocumentPresenter {
 
      - Parameter urlString: An Instant document URL scanned from a barcode or entered by the user.
      */
-    func joinExistingSession(withURL urlString: String) {
+    public func joinExistingSession(withURL urlString: String) {
         guard let url = URL(string: urlString) else {
             showAlert(withTitle: "Couldn’t Join Group", message: "This is not a link. Please enter an Instant document link.")
             return
@@ -55,8 +55,8 @@ class InstantDocumentPresenter {
      Loads an Instant session using the specified API call. The passed in closure should run an
      asynchronous API call. That closure will be passed another closure to run on completion.
      */
-    private func loadSession(loadingMessage: String, APICall: @escaping (@escaping WebPreviewAPIClient.CompletionHandler) -> Void) {
-        let progressHUDItem = PSPDFStatusHUDItem.indeterminateProgress(withText: loadingMessage)
+    private func loadSession(loadingMessage: String, APICall: @escaping (@escaping WebExamplesAPIClient.CompletionHandler) -> Void) {
+        let progressHUDItem = StatusHUDItem.indeterminateProgress(withText: loadingMessage)
         progressHUDItem.setHUDStyle(.black)
 
         progressHUDItem.push(animated: true, on: presentingViewController?.view.window) {
@@ -72,7 +72,7 @@ class InstantDocumentPresenter {
                             self.showAlert(withTitle: "Couldn’t Set Up Instant", message: error.localizedDescription)
                         }
 
-                    case .failure(WebPreviewAPIClient.Failure.cancelled):
+                    case .failure(WebExamplesAPIClient.Failure.cancelled):
                         break // Do not show the alert if user cancelled the request themselves.
 
                     case let .failure(otherError):
@@ -94,7 +94,7 @@ class InstantDocumentPresenter {
 
     private func showAlert(withTitle title: String, message: String) {
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
+        alertController.addAction(UIAlertAction(title: "OK", style: .cancel))
 
         presentOnFrontmostViewController(alertController)
     }

--- a/samples/NativeCatalog/ios/InstantExample/InstantDocumentPresenter.swift
+++ b/samples/NativeCatalog/ios/InstantExample/InstantDocumentPresenter.swift
@@ -1,0 +1,110 @@
+//
+//  Copyright © 2018-2020 PSPDFKit GmbH. All rights reserved.
+//
+//  THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY INTERNATIONAL COPYRIGHT LAW
+//  AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT.
+//  UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
+//  This notice may not be removed from this file.
+//
+
+import PSPDFKitUI
+
+/**
+ Connects to our public PSPDFKit for Web examples server to present documents managed by PSPDFKit Instant.
+ This is decoupled from any view controller in order to support loading documents by opening URLs.
+ */
+class InstantDocumentPresenter {
+    /**
+     Interfaces with our Web examples server to create and access documents.
+     In your own app you would connect to your own server backend to get Instant document identifiers and authentication tokens.
+     */
+    private lazy var apiClient = WebPreviewAPIClient(presentingViewController: presentingViewController)
+
+    /// View controller that can present other view controllers.
+    private weak var presentingViewController: UIViewController?
+
+    /// Initialize a document presenter with a view controller that can present other view controllers.
+    init(presentingViewController: UIViewController) {
+        self.presentingViewController = presentingViewController
+    }
+
+    /// Tries to create a new Instant session.
+    func createNewSession() {
+        loadSession(loadingMessage: "Creating") { completion in
+            self.apiClient.createNewSession(completion: completion)
+        }
+    }
+
+    /**
+     Tries to join an existing Instant session or shows an alert on failure.
+
+     - Parameter urlString: An Instant document URL scanned from a barcode or entered by the user.
+     */
+    func joinExistingSession(withURL urlString: String) {
+        guard let url = URL(string: urlString) else {
+            showAlert(withTitle: "Couldn’t Join Group", message: "This is not a link. Please enter an Instant document link.")
+            return
+        }
+
+        loadSession(loadingMessage: "Verifying") { completion in
+            self.apiClient.resolveExistingSessionURL(url, completion: completion)
+        }
+    }
+
+    /**
+     Loads an Instant session using the specified API call. The passed in closure should run an
+     asynchronous API call. That closure will be passed another closure to run on completion.
+     */
+    private func loadSession(loadingMessage: String, APICall: @escaping (@escaping WebPreviewAPIClient.CompletionHandler) -> Void) {
+        let progressHUDItem = PSPDFStatusHUDItem.indeterminateProgress(withText: loadingMessage)
+        progressHUDItem.setHUDStyle(.black)
+
+        progressHUDItem.push(animated: true, on: presentingViewController?.view.window) {
+            APICall { result in
+                DispatchQueue.main.async {
+                    progressHUDItem.pop(animated: true, completion: nil)
+
+                    switch result {
+                    case let .success(documentInfo):
+                        do {
+                            try self.openDocument(with: documentInfo)
+                        } catch {
+                            self.showAlert(withTitle: "Couldn’t Set Up Instant", message: error.localizedDescription)
+                        }
+
+                    case .failure(WebPreviewAPIClient.Failure.cancelled):
+                        break // Do not show the alert if user cancelled the request themselves.
+
+                    case let .failure(otherError):
+                        self.showAlert(withTitle: "Couldn’t Get Instant Document Info", message: otherError.localizedDescription)
+                    }
+                }
+            }
+        }
+    }
+
+    private func openDocument(with info: InstantDocumentInfo) throws {
+        let instantViewController = try InstantDocumentViewController(documentInfo: info)
+
+        let navigationController = UINavigationController(rootViewController: instantViewController)
+        navigationController.modalPresentationStyle = .fullScreen
+
+        presentOnFrontmostViewController(navigationController)
+    }
+
+    private func showAlert(withTitle title: String, message: String) {
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
+
+        presentOnFrontmostViewController(alertController)
+    }
+
+    private func presentOnFrontmostViewController(_ viewController: UIViewController) {
+        guard let rootViewController = presentingViewController?.viewIfLoaded?.window?.rootViewController else {
+            print("Couldn’t show view controller because no root view controller was found.")
+            return
+        }
+
+        rootViewController.psc_frontmost.present(viewController, animated: true, completion: nil)
+    }
+}

--- a/samples/NativeCatalog/ios/InstantExample/InstantDocumentViewController.swift
+++ b/samples/NativeCatalog/ios/InstantExample/InstantDocumentViewController.swift
@@ -1,0 +1,136 @@
+//
+//  Copyright © 2019-2020 PSPDFKit GmbH. All rights reserved.
+//
+//  The PSPDFKit Sample applications are licensed with a modified BSD license.
+//  Please see License for details. This notice may not be removed from this file.
+//
+
+import Instant
+
+/**
+ Downloads and shows a document managed by Instant, and shows a
+ button to share the document URL so you can see Instant syncing.
+ */
+class InstantDocumentViewController: PSPDFInstantViewController {
+    private let documentInfo: InstantDocumentInfo
+    private let client: PSPDFInstantClient
+    private let documentDescriptor: PSPDFInstantDocumentDescriptor
+
+    init(documentInfo: InstantDocumentInfo) throws {
+        /*
+         Create the Instant objects with the information from the PSPDFKit for Web examples server.
+
+         The `PSPDFDocument` you get from Instant does not retain the objects that create it,
+         so we need to keep references to the client and document descriptor otherwise with no
+         strong references they would deallocate and syncing would stop.
+         */
+        client = try PSPDFInstantClient(serverURL: documentInfo.serverURL)
+
+        documentDescriptor = try client.documentDescriptor(forJWT: documentInfo.jwt)
+
+        // Store document info for sharing later.
+        self.documentInfo = documentInfo
+
+        // Tell Instant to download the document from Web examples server’s PSPDFKit Server instance.
+        do {
+            try documentDescriptor.download(usingJWT: documentInfo.jwt)
+        } catch PSPDFInstantError.alreadyDownloaded {
+            // This is fine, we only have to reauthenticate. Any other errors are passed up.
+            documentDescriptor.reauthenticate(withJWT: documentInfo.jwt)
+        }
+
+        // Get the `PSPDFDocument` from Instant.
+        let pdfDocument = documentDescriptor.editableDocument
+
+        let configuration = PSPDFConfiguration { builder in
+            builder.pageTransition = .scrollContinuous
+            builder.scrollDirection = .vertical
+        }
+
+        // Set the document on the `PSPDFInstantViewController` (the superclass) so it can show the download progress, and then show the document.
+        super.init(document: pdfDocument, configuration: configuration)
+
+        let collaborateItem = UIBarButtonItem(title: "Collaborate", style: .plain, target: self, action: #selector(showCollaborationOptions(_:)))
+        let barButtonItems = [collaborateItem, annotationButtonItem]
+        navigationItem.setRightBarButtonItems(barButtonItems, for: .document, animated: false)
+    }
+
+    @available(*, unavailable)
+    required init?(coder decoder: NSCoder) {
+        fatalError("init(coder:) is not supported.")
+    }
+
+    deinit {
+        do {
+            /*
+             Since this demo is ephemeral, clean up immediately.
+             Note that this also cancels syncing that is in-progress.
+             */
+            try documentDescriptor.removeLocalStorage()
+        } catch {
+            print("Could not remove Instant document storage: \(error)")
+        }
+    }
+
+    private let notificationNames: [Notification.Name] = [.PSPDFInstantDidFailDownload, .PSPDFInstantDidFailSyncing, .PSPDFInstantDidFailAuthentication, .PSPDFInstantDidFailReauthentication]
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        for name in notificationNames {
+            NotificationCenter.default.addObserver(self, selector: #selector(showError(notification:)), name: name, object: documentDescriptor)
+        }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        for name in notificationNames {
+            NotificationCenter.default.removeObserver(self, name: name, object: documentDescriptor)
+        }
+    }
+
+    @objc private func showError(notification: Notification) {
+        // Notifications from Instant will be posted on a background thread.
+        DispatchQueue.main.async {
+
+            let title: String
+            switch notification.name {
+            case .PSPDFInstantDidFailDownload:
+                title = "Couldn’t Download Document"
+            case .PSPDFInstantDidFailSyncing:
+                title = "Couldn’t Sync"
+            case .PSPDFInstantDidFailAuthentication:
+                title = "Couldn’t Authenticate"
+            case .PSPDFInstantDidFailReauthentication:
+                title = "Couldn’t Reauthenticate"
+            default:
+                fatalError("Unexpected notification name \(notification.name)")
+            }
+
+            let error = notification.userInfo?[PSPDFInstantErrorKey] as? NSError
+
+            let alertController = UIAlertController(title: title, message: error?.localizedDescription, preferredStyle: .alert)
+            alertController.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
+            self.psc_frontmost.present(alertController, animated: true, completion: nil)
+        }
+    }
+
+    @objc private func showCollaborationOptions(_ sender: UIBarButtonItem) {
+        let alertController = UIAlertController(title: documentInfo.url.absoluteString, message: nil, preferredStyle: .actionSheet)
+        alertController.popoverPresentationController?.barButtonItem = sender
+
+        alertController.addAction(UIAlertAction(title: "Open in Safari", style: .default, handler: { [unowned self] _ in
+            UIApplication.shared.open(self.documentInfo.url, options: [:], completionHandler: nil)
+        }))
+        alertController.addAction(UIAlertAction(title: "Share Document Link", style: .default, handler: { [unowned self] _ in
+            let activityViewController = UIActivityViewController(activityItems: [self.documentInfo.url], applicationActivities: nil)
+            activityViewController.popoverPresentationController?.barButtonItem = sender
+
+            self.present(activityViewController, animated: true)
+        }))
+        alertController.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+
+        present(alertController, animated: true)
+    }
+}

--- a/samples/NativeCatalog/ios/InstantExample/InstantExample.swift
+++ b/samples/NativeCatalog/ios/InstantExample/InstantExample.swift
@@ -33,7 +33,7 @@ import Instant
 /// Shows UI to either start a new collaboration session or join an existing session.
 @objc class InstantExampleViewController: UITableViewController {
 
-    private lazy var apiClient = WebPreviewAPIClient(presentingViewController: self)
+    private lazy var apiClient = WebExamplesAPIClient(presentingViewController: self)
     private lazy var instantDocumentPresenter = InstantDocumentPresenter(presentingViewController: self)
 
     /// A reference to the text field in the cell so it can be disabled when starting a new group to avoid duplicate network requests.
@@ -46,7 +46,7 @@ import Instant
         // Since this demo is ephemeral, we want to ensure we start with a clean slate each time.
         // The InstantDocumentViewController tries to clean up when it deallocates but that can’t catch every case.
         do {
-            try FileManager.default.removeItem(at: PSPDFInstantClient.dataDirectory)
+            try FileManager.default.removeItem(at: InstantClient.dataDirectory)
         } catch {
             switch error {
             case CocoaError.fileNoSuchFile,
@@ -180,7 +180,7 @@ import Instant
 
     private func showError(withTitle title: String, message: String) {
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
+        alertController.addAction(UIAlertAction(title: "OK", style: .cancel))
 
         present(alertController, animated: true, completion: nil)
     }

--- a/samples/NativeCatalog/ios/InstantExample/InstantExample.swift
+++ b/samples/NativeCatalog/ios/InstantExample/InstantExample.swift
@@ -1,0 +1,259 @@
+//
+//  Copyright © 2017-2020 PSPDFKit GmbH. All rights reserved.
+//
+//  The PSPDFKit Sample applications are licensed with a modified BSD license.
+//  Please see License for details. This notice may not be removed from this file.
+//
+
+import Instant
+
+/**
+ This example connects to our public PSPDFKit for Web examples server and downloads documents using PSPDFKit Instant.
+ You can then collaboratively annotate these documents using Instant.
+ Each document on the PSPDFKit for Web examples server can be accessed via its URL.
+
+ The example lets you either create a new collaboration group then share the URL,
+ or join an existing collaboration group by entering a URL.
+ To speed this up, the URL can be read from a QR code.
+
+ Other supported clients include:
+
+ - PSPDFKit Instant Live Demo: https://pspdfkit.com/instant/demo/
+ - PSPDFKit for Web examples: https://web-examples.pspdfkit.com
+ - PDF Viewer for iOS and Android: https://pdfviewer.io
+ - PSPDFKit Catalog example app for Android
+
+ As is usually the case with Instant, most of the code here deals with communicating with the
+ particular server backend (our Web examples server in this case), so is not particularly useful
+ as example code. The same applies to the other files in this folder.
+
+ The code actually interacting with the Instant framework API is in `InstantDocumentViewController.swift`.
+ */
+
+/// Shows UI to either start a new collaboration session or join an existing session.
+@objc class InstantExampleViewController: UITableViewController {
+
+    private lazy var apiClient = WebPreviewAPIClient(presentingViewController: self)
+    private lazy var instantDocumentPresenter = InstantDocumentPresenter(presentingViewController: self)
+
+    /// A reference to the text field in the cell so it can be disabled when starting a new group to avoid duplicate network requests.
+    weak var codeTextField: UITextField?
+
+    init() {
+        super.init(style: .grouped)
+        title = "PSPDFKit Instant"
+
+        // Since this demo is ephemeral, we want to ensure we start with a clean slate each time.
+        // The InstantDocumentViewController tries to clean up when it deallocates but that can’t catch every case.
+        do {
+            try FileManager.default.removeItem(at: PSPDFInstantClient.dataDirectory)
+        } catch {
+            switch error {
+            case CocoaError.fileNoSuchFile,
+                 CocoaError.fileReadNoSuchFile:
+                // If the directory does not exist, it is technically an error, but a happy one.
+                break
+            default:
+                print("Could not remove Instant data directory: \(error)")
+            }
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder decoder: NSCoder) {
+        fatalError("init(coder:) is not supported.")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        tableView.keyboardDismissMode = .onDrag
+        tableView.cellLayoutMarginsFollowReadableWidth = true
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: CellIdentifier.newGroup.rawValue)
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: CellIdentifier.scanCode.rawValue)
+        tableView.register(TextFieldCell.self, forCellReuseIdentifier: CellIdentifier.urlField.rawValue)
+    }
+
+    enum CellIdentifier: String {
+        case newGroup = "new group"
+        case scanCode = "scan code"
+        case urlField = "url field"
+    }
+
+    struct Row {
+        let identifier: CellIdentifier
+        let allowsHighlight: Bool
+    }
+
+    struct Section {
+        let header: String?
+        let rows: [Row]
+        let footer: String?
+    }
+
+    /// Data to show in the table view.
+    private let sections: [Section] = [
+        Section(header: "Seamless collaboration for PSPDFKit-powered apps", rows: [], footer: "The PSPDFKit SDKs support Instant out of the box. Just connect your app to an Instant server and document management and syncing is taken care of."),
+        Section(header: "Start a new group", rows: [Row(identifier: .newGroup, allowsHighlight: true)], footer: "Get a new document link, then collaborate by entering it in PSPDFKit Catalog on another device, or opening the document link in a web browser."),
+        Section(header: "Join a group", rows: [Row(identifier: .scanCode, allowsHighlight: true), Row(identifier: .urlField, allowsHighlight: false)], footer: "Scan or enter a document link from PDF Viewer or PSPDFKit Catalog on another device, or from a web browser showing pspdfkit.com/instant/demo or web-examples.pspdfkit.com."),
+    ]
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return sections.count
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return sections[section].rows.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = sections[indexPath.section].rows[indexPath.row]
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.identifier.rawValue, for: indexPath)
+
+        cell.textLabel?.textColor = tableView.tintColor
+        cell.textLabel?.font = UIFont.preferredFont(forTextStyle: .headline)
+
+        switch row.identifier {
+        case .newGroup:
+            cell.textLabel?.text = "Create Group"
+            return cell
+
+        case .scanCode:
+            cell.textLabel?.text = "Scan QR Code"
+            return cell
+
+        case .urlField:
+            let textField = (cell as! TextFieldCell).textField
+
+            codeTextField = textField
+
+            textField.delegate = self
+            return cell
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return sections[section].header
+    }
+
+    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return sections[section].footer
+    }
+
+    override func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
+        return sections[indexPath.section].rows[indexPath.row].allowsHighlight
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let rowId = sections[indexPath.section].rows[indexPath.row].identifier
+
+        switch rowId {
+        case .newGroup:
+            instantDocumentPresenter.createNewSession()
+        case .scanCode:
+            requestPermissionAndPresentScanner()
+        case .urlField:
+            fatalError("Shouldn’t be able to select URL field cell.")
+        }
+    }
+
+    private func requestPermissionAndPresentScanner() {
+        AVCaptureDevice.requestAccess(for: .video) { [weak self] (granted: Bool) -> Void in
+            DispatchQueue.main.async {
+                guard let self = self else {
+                    return
+                }
+                if granted {
+                    let scannerVC = ScannerViewController()
+                    scannerVC.delegate = self
+                    let navigationVC = UINavigationController(rootViewController: scannerVC)
+                    navigationVC.modalPresentationStyle = .fullScreen
+
+                    self.navigationController?.present(navigationVC, animated: true, completion: nil)
+                } else {
+                    self.tableView.selectRow(at: nil, animated: true, scrollPosition: .none)
+                    self.showError(withTitle: "Camera Access Needed", message: "To scan QR codes, enable camera access in the Settings app.")
+                }
+            }
+        }
+    }
+
+    private func showError(withTitle title: String, message: String) {
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
+
+        present(alertController, animated: true, completion: nil)
+    }
+}
+
+// MARK: - Text field delegate
+
+extension InstantExampleViewController: UITextFieldDelegate {
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        guard let text = textField.text else {
+            return false
+        }
+
+        instantDocumentPresenter.joinExistingSession(withURL: text)
+        return true
+    }
+}
+
+// MARK: - Scanner view controller delegate
+
+extension InstantExampleViewController: ScannerViewControllerDelegate {
+
+    func scannerViewController(_ scannerViewController: ScannerViewController, didFinishScanningWith result: BarcodeScanResult) {
+        if case .success(let barcode) = result {
+            codeTextField?.text = barcode
+        }
+
+        self.dismiss(animated: true) {
+            switch result {
+            case .success(let barcode):
+                self.instantDocumentPresenter.joinExistingSession(withURL: barcode)
+            case .failure(let errorMessage):
+                self.showError(withTitle: "Couldn’t Scan QR Code", message: errorMessage)
+            }
+        }
+    }
+}
+
+// MARK: -
+
+class TextFieldCell: UITableViewCell {
+    let textField = UITextField()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        textField.placeholder = "Or Enter Document Link"
+
+        textField.clearButtonMode = .always
+        textField.keyboardType = .alphabet
+        textField.autocorrectionType = .no
+        textField.autocapitalizationType = .none
+        textField.returnKeyType = .done
+
+        textField.font = UIFont.preferredFont(forTextStyle: .headline)
+
+        contentView.addSubview(textField)
+    }
+
+    required init?(coder decoder: NSCoder) {
+        fatalError("init(coder:) is not supported.")
+    }
+
+    override func sizeThatFits(_ size: CGSize) -> CGSize {
+        let availableWidth = size.width - layoutMargins.left - layoutMargins.right
+        let height = layoutMargins.top + textField.sizeThatFits(CGSize(width: availableWidth, height: .greatestFiniteMagnitude)).height + layoutMargins.bottom
+        return CGSize(width: size.width, height: max(height, 44))
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        textField.frame = convert(bounds.inset(by: layoutMargins), to: contentView)
+    }
+}

--- a/samples/NativeCatalog/ios/InstantExample/ScannerViewController.swift
+++ b/samples/NativeCatalog/ios/InstantExample/ScannerViewController.swift
@@ -1,0 +1,171 @@
+//
+//  Copyright © 2018-2020 PSPDFKit GmbH. All rights reserved.
+//
+//  THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY INTERNATIONAL COPYRIGHT LAW
+//  AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT.
+//  UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
+//  This notice may not be removed from this file.
+//
+
+import AVFoundation
+import PSPDFKitUI
+
+/// The possible results of barcode scanning.
+enum BarcodeScanResult {
+    case success(barcode: String)
+    case failure(error: String)
+}
+
+protocol ScannerViewControllerDelegate: class {
+    /// Notifies the delegate when a scanning result is obtained. This will be called on the main thread.
+    func scannerViewController(_ scannerViewController: ScannerViewController, didFinishScanningWith result: BarcodeScanResult)
+}
+
+private class BarcodeScannerView: UIView {
+
+    weak var previewLayer: AVCaptureVideoPreviewLayer?
+
+    convenience init(_ previewLayer: AVCaptureVideoPreviewLayer) {
+        self.init()
+
+        previewLayer.videoGravity = .resizeAspectFill
+        layer.addSublayer(previewLayer)
+        self.previewLayer = previewLayer
+    }
+
+    @available(iOS, deprecated: 11.0) // Hide deprecation warning for statusBarOrientation
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        guard let previewLayer = previewLayer else { return }
+        previewLayer.frame = self.layer.bounds
+        previewLayer.connection?.videoOrientation = UIApplication.shared.statusBarOrientation.convertToAVCaptureVideoOrientation()
+    }
+}
+
+/// A view controller that shows the device camera and notifies its delegate when a barcode is found.
+class ScannerViewController: UIViewController {
+    private var previewLayer: AVCaptureVideoPreviewLayer?
+    private var scannerQueue = DispatchQueue(label: "com.pspdfkit.viewer.scanner-queue", qos: .userInitiated)
+    weak var delegate: ScannerViewControllerDelegate?
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = "Scan QR Code"
+        edgesForExtendedLayout = []
+        view.backgroundColor = UIColor.black
+
+        let captureSession = AVCaptureSession()
+        let previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
+
+        scannerQueue.async { [weak self] in
+            guard let self = self else { return }
+            self.setupScanning(captureSession: captureSession)
+        }
+
+        let scannerView = BarcodeScannerView(previewLayer)
+        scannerView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(scannerView)
+
+        NSLayoutConstraint.activate([
+            scannerView.topAnchor.constraint(equalTo: view.topAnchor),
+            scannerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            scannerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scannerView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+
+        self.previewLayer = previewLayer
+        navigationController?.navigationBar.prefersLargeTitles = true
+
+        navigationItem.leftBarButtonItem = UIBarButtonItem(image: PSPDFKitGlobal.imageNamed("x"), style: .done, target: self, action: #selector(closePressed))
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        if let captureSession = previewLayer?.session, captureSession.isRunning {
+            scannerQueue.async {
+                captureSession.stopRunning()
+            }
+        }
+    }
+
+    func setupScanning(captureSession: AVCaptureSession) {
+        guard let videoCaptureDevice = AVCaptureDevice.default(for: .video),
+            let videoInput = try? AVCaptureDeviceInput(device: videoCaptureDevice) else { return }
+
+        precondition(captureSession.canAddInput(videoInput))
+        captureSession.addInput(videoInput)
+
+        // Metadata output is used to get callbacks when camera detects barcode
+        let metadataOutput = AVCaptureMetadataOutput()
+
+        if captureSession.canAddOutput(metadataOutput) {
+            captureSession.addOutput(metadataOutput)
+
+            metadataOutput.metadataObjectTypes = [.qr]
+
+            // See explanation at the top of this class to find out why this is necessary.
+            metadataOutput.perform(#selector(AVCaptureMetadataOutput.setMetadataObjectsDelegate(_:queue:)), with: self, with: scannerQueue)
+
+            metadataOutput.setMetadataObjectsDelegate(self, queue: scannerQueue)
+
+            // start running the capture session only once the setup is completed
+            captureSession.startRunning()
+        } else {
+            let errorString = "Scanning is not supported on this device."
+            self.delegate?.scannerViewController(self, didFinishScanningWith: .failure(error: errorString))
+        }
+    }
+
+    @objc func closePressed() {
+        self.dismiss(animated: true, completion: nil)
+    }
+}
+
+extension ScannerViewController: AVCaptureMetadataOutputObjectsDelegate {
+    func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
+        if let captureSession = previewLayer?.session, captureSession.isRunning {
+            captureSession.stopRunning()
+        }
+
+        guard let metadataObject = metadataObjects.first,
+            let readableObject = metadataObject as? AVMetadataMachineReadableCodeObject,
+            let stringValue = readableObject.stringValue else {
+                DispatchQueue.main.async {
+                    self.delegate?.scannerViewController(self, didFinishScanningWith: .failure(error: "Didn’t find anything to scan."))
+                }
+                return
+        }
+
+        DispatchQueue.main.async {
+            self.delegate?.scannerViewController(self, didFinishScanningWith: .success(barcode: stringValue))
+        }
+    }
+}
+
+extension UIInterfaceOrientation {
+    func convertToAVCaptureVideoOrientation() -> AVCaptureVideoOrientation {
+        switch self {
+        case .landscapeLeft:
+            return AVCaptureVideoOrientation.landscapeLeft
+        case .landscapeRight:
+            return AVCaptureVideoOrientation.landscapeRight
+        case .portraitUpsideDown:
+            return AVCaptureVideoOrientation.portraitUpsideDown
+        case .portrait, .unknown:
+            return AVCaptureVideoOrientation.portrait
+        @unknown default:
+            fatalError()
+        }
+    }
+}

--- a/samples/NativeCatalog/ios/InstantExample/ScannerViewController.swift
+++ b/samples/NativeCatalog/ios/InstantExample/ScannerViewController.swift
@@ -86,7 +86,7 @@ class ScannerViewController: UIViewController {
         self.previewLayer = previewLayer
         navigationController?.navigationBar.prefersLargeTitles = true
 
-        navigationItem.leftBarButtonItem = UIBarButtonItem(image: PSPDFKitGlobal.imageNamed("x"), style: .done, target: self, action: #selector(closePressed))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(image: SDK.imageNamed("x"), style: .done, target: self, action: #selector(closePressed))
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/samples/NativeCatalog/ios/InstantExample/WebExamplesAPIClient.swift
+++ b/samples/NativeCatalog/ios/InstantExample/WebExamplesAPIClient.swift
@@ -13,7 +13,7 @@ import Foundation
  This is just networking and JSON parsing. It’s very specific our backend so not very useful as sample code.
  In your own app you would connect to your own server backend to get Instant document identifiers and authentication tokens.
  */
-class WebPreviewAPIClient: NSObject, URLSessionTaskDelegate {
+class WebExamplesAPIClient: NSObject, URLSessionTaskDelegate {
 
     enum Failure: Error {
         case cancelled
@@ -72,7 +72,7 @@ class WebPreviewAPIClient: NSObject, URLSessionTaskDelegate {
 
     private func promptForHTTPBasicAuthenticationCredential(challenge: URLAuthenticationChallenge, completion: @escaping (URLCredential?) -> Void) {
         let hudWindow = presentingViewController?.view.window
-        let hudItems = PSPDFStatusHUD.itemsForHUD(on: hudWindow)
+        let hudItems = StatusHUD.itemsForHUD(on: hudWindow)
         let alert = UIAlertController(title: "Log in to \(challenge.protectionSpace.host)", message: "Your login information will be sent securely.", preferredStyle: .alert)
 
         alert.addTextField { textField in
@@ -86,14 +86,14 @@ class WebPreviewAPIClient: NSObject, URLSessionTaskDelegate {
         }
 
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel) { _ in
-            PSPDFStatusHUD.pushItems(hudItems, on: hudWindow, animated: true) {
+            StatusHUD.pushItems(hudItems, on: hudWindow, animated: true) {
                 completion(nil)
             }
         }
 
         let logInAction = UIAlertAction(title: "Log In", style: .default) { [unowned alert] _ in
             guard let textFields = alert.textFields, textFields.count == 2 else {
-                PSPDFStatusHUD.pushItems(hudItems, on: hudWindow, animated: true) {
+                StatusHUD.pushItems(hudItems, on: hudWindow, animated: true) {
                     completion(nil)
                 }
                 return
@@ -103,7 +103,7 @@ class WebPreviewAPIClient: NSObject, URLSessionTaskDelegate {
                 password: textFields[1].text ?? "",
                 persistence: .permanent
             )
-            PSPDFStatusHUD.pushItems(hudItems, on: hudWindow, animated: true) {
+            StatusHUD.pushItems(hudItems, on: hudWindow, animated: true) {
                 completion(credential)
             }
         }
@@ -111,7 +111,7 @@ class WebPreviewAPIClient: NSObject, URLSessionTaskDelegate {
         alert.addAction(cancelAction)
         alert.addAction(logInAction)
 
-        PSPDFStatusHUD.popItems(hudItems, animated: true) {
+        StatusHUD.popItems(hudItems, animated: true) {
             self.presentingViewController?.present(alert, animated: true)
         }
     }
@@ -146,7 +146,7 @@ class WebPreviewAPIClient: NSObject, URLSessionTaskDelegate {
     }
 }
 
-extension WebPreviewAPIClient.Failure: LocalizedError {
+extension WebExamplesAPIClient.Failure: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .cancelled:
@@ -161,9 +161,9 @@ extension WebPreviewAPIClient.Failure: LocalizedError {
     }
 }
 
-extension PSPDFStatusHUD {
+extension StatusHUD {
 
-    fileprivate static func popItems(_ items: [PSPDFStatusHUDItem]?, animated: Bool, completion: @escaping () -> Void) {
+    fileprivate static func popItems(_ items: [StatusHUDItem]?, animated: Bool, completion: @escaping () -> Void) {
         guard let items = items, !items.isEmpty else {
             completion()
             return
@@ -172,7 +172,7 @@ extension PSPDFStatusHUD {
         items.last!.pop(animated: animated, completion: completion)
     }
 
-    fileprivate static func pushItems(_ items: [PSPDFStatusHUDItem]?, on window: UIWindow?, animated: Bool, completion: @escaping () -> Void) {
+    fileprivate static func pushItems(_ items: [StatusHUDItem]?, on window: UIWindow?, animated: Bool, completion: @escaping () -> Void) {
         guard let items = items, !items.isEmpty else {
             completion()
             return

--- a/samples/NativeCatalog/ios/InstantExample/WebPreviewAPIClient.swift
+++ b/samples/NativeCatalog/ios/InstantExample/WebPreviewAPIClient.swift
@@ -1,0 +1,184 @@
+//
+//  Copyright © 2017-2020 PSPDFKit GmbH. All rights reserved.
+//
+//  The PSPDFKit Sample applications are licensed with a modified BSD license.
+//  Please see License for details. This notice may not be removed from this file.
+//
+
+import Foundation
+
+/**
+ Interfaces with our PSPDFKit for Web examples server.
+
+ This is just networking and JSON parsing. It’s very specific our backend so not very useful as sample code.
+ In your own app you would connect to your own server backend to get Instant document identifiers and authentication tokens.
+ */
+class WebPreviewAPIClient: NSObject, URLSessionTaskDelegate {
+
+    enum Failure: Error {
+        case cancelled
+        case invalidCode
+        case internalError(underlying: Error?)
+    }
+
+    typealias APIResult = Result<InstantDocumentInfo, Error>
+    typealias CompletionHandler = (_ result: APIResult) -> Void
+
+    private lazy var session = URLSession(configuration: .default, delegate: self, delegateQueue: .main)
+    private weak var presentingViewController: UIViewController?
+
+    init(presentingViewController: UIViewController?) {
+        self.presentingViewController = presentingViewController
+        super.init()
+    }
+
+    /// Starts a new collaboration group. The completion handler may be called on a background thread.
+    func createNewSession(completion: @escaping CompletionHandler) {
+        var request = URLRequest(url: URL(string: "https://web-examples.pspdfkit.com/api/instant-landing-page")!)
+        request.httpMethod = "POST"
+
+        startDataTask(with: request, completion: completion)
+    }
+
+    /// Tries to access an existing collaboration group. The completion handler may be called on a background thread.
+    func resolveExistingSessionURL(_ url: URL, completion: @escaping CompletionHandler) {
+        var request = URLRequest(url: url)
+        request.addValue("application/vnd.instant-example+json", forHTTPHeaderField: "Accept")
+
+        startDataTask(with: request, completion: completion)
+    }
+
+    private func startDataTask(with request: URLRequest, completion: @escaping CompletionHandler) {
+        let task = session.dataTask(with: request) { data, response, error in
+            let result = self.resultFromResponse(with: data, response: response, error: error)
+            completion(result)
+        }
+        task.resume()
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPBasic, challenge.proposedCredential?.password == nil {
+            promptForHTTPBasicAuthenticationCredential(challenge: challenge) { providedCredential in
+                if let providedCredential = providedCredential {
+                    completionHandler(.useCredential, providedCredential)
+                } else {
+                    completionHandler(.cancelAuthenticationChallenge, nil)
+                }
+            }
+        } else {
+            completionHandler(.performDefaultHandling, challenge.proposedCredential)
+        }
+    }
+
+    private func promptForHTTPBasicAuthenticationCredential(challenge: URLAuthenticationChallenge, completion: @escaping (URLCredential?) -> Void) {
+        let hudWindow = presentingViewController?.view.window
+        let hudItems = PSPDFStatusHUD.itemsForHUD(on: hudWindow)
+        let alert = UIAlertController(title: "Log in to \(challenge.protectionSpace.host)", message: "Your login information will be sent securely.", preferredStyle: .alert)
+
+        alert.addTextField { textField in
+            textField.placeholder = "Username"
+            textField.text = challenge.proposedCredential?.user
+        }
+
+        alert.addTextField { textField in
+            textField.isSecureTextEntry = true
+            textField.placeholder = "Password"
+        }
+
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel) { _ in
+            PSPDFStatusHUD.pushItems(hudItems, on: hudWindow, animated: true) {
+                completion(nil)
+            }
+        }
+
+        let logInAction = UIAlertAction(title: "Log In", style: .default) { [unowned alert] _ in
+            guard let textFields = alert.textFields, textFields.count == 2 else {
+                PSPDFStatusHUD.pushItems(hudItems, on: hudWindow, animated: true) {
+                    completion(nil)
+                }
+                return
+            }
+            let credential = URLCredential(
+                user: textFields[0].text ?? "",
+                password: textFields[1].text ?? "",
+                persistence: .permanent
+            )
+            PSPDFStatusHUD.pushItems(hudItems, on: hudWindow, animated: true) {
+                completion(credential)
+            }
+        }
+
+        alert.addAction(cancelAction)
+        alert.addAction(logInAction)
+
+        PSPDFStatusHUD.popItems(hudItems, animated: true) {
+            self.presentingViewController?.present(alert, animated: true)
+        }
+    }
+
+    private func resultFromResponse(with data: Data?, response: URLResponse?, error: Error?) -> APIResult {
+        if let error = error as? URLError {
+            switch error.code {
+            case .cancelled:
+                return .failure(Failure.cancelled)
+            default:
+                return .failure(Failure.internalError(underlying: error))
+            }
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            return .failure(Failure.internalError(underlying: nil))
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            if let data = data, let json = try? JSONSerialization.jsonObject(with: data) {
+                if let document = InstantDocumentInfo(json: json) {
+                    return .success(document)
+                }
+            }
+            return .failure(Failure.internalError(underlying: nil))
+        case 400:
+            return .failure(Failure.invalidCode)
+        default:
+            return .failure(Failure.internalError(underlying: nil))
+        }
+    }
+}
+
+extension WebPreviewAPIClient.Failure: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .cancelled:
+            return "The request has been cancelled."
+        case .invalidCode:
+            return "The document code is invalid."
+        case .internalError(let underlying?):
+            return "An error occurred: \(underlying)"
+        case .internalError(nil):
+            return "An internal error occurred."
+        }
+    }
+}
+
+extension PSPDFStatusHUD {
+
+    fileprivate static func popItems(_ items: [PSPDFStatusHUDItem]?, animated: Bool, completion: @escaping () -> Void) {
+        guard let items = items, !items.isEmpty else {
+            completion()
+            return
+        }
+        items.dropLast().forEach { $0.pop(animated: true, completion: nil) }
+        items.last!.pop(animated: animated, completion: completion)
+    }
+
+    fileprivate static func pushItems(_ items: [PSPDFStatusHUDItem]?, on window: UIWindow?, animated: Bool, completion: @escaping () -> Void) {
+        guard let items = items, !items.isEmpty else {
+            completion()
+            return
+        }
+        items.dropLast().forEach { $0.push(animated: animated, on: window, completion: nil) }
+        items.last!.push(animated: animated, on: window, completion: completion)
+    }
+
+}

--- a/samples/NativeCatalog/ios/NativeCatalog.xcodeproj/project.pbxproj
+++ b/samples/NativeCatalog/ios/NativeCatalog.xcodeproj/project.pbxproj
@@ -12,18 +12,18 @@
 		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		35C3D672073CC7D4C99F4A95 /* libPods-NativeCatalog.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B068A47725170C7A2100EE53 /* libPods-NativeCatalog.a */; };
-		4C20D1CACDACD8BD8B8DDD6A /* libPods-NativeCatalogTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 67D4656F82A81B754BB705C8 /* libPods-NativeCatalogTests.a */; };
+		2AD52A55D07643AD7BFAA381 /* libPods-NativeCatalog.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E6B9903E5A6F6239013AC3FB /* libPods-NativeCatalog.a */; };
+		5791F4E044E07A89757F0251 /* libPods-NativeCatalogTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D3645470FDC1D2846E8C6A15 /* libPods-NativeCatalogTests.a */; };
 		844D64C02375A9FE004E70D2 /* CustomPdfView.m in Sources */ = {isa = PBXBuildFile; fileRef = 844D64BF2375A9FE004E70D2 /* CustomPdfView.m */; };
 		844D64C32375AA44004E70D2 /* CustomPdfViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 844D64C22375AA44004E70D2 /* CustomPdfViewManager.m */; };
 		844D64E62375B5FC004E70D2 /* PDFs in Resources */ = {isa = PBXBuildFile; fileRef = 844D64E52375B5FC004E70D2 /* PDFs */; };
 		84E53901242E2972002F99F2 /* ScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E538FB242E2972002F99F2 /* ScannerViewController.swift */; };
-		84E53902242E2972002F99F2 /* WebPreviewAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E538FC242E2972002F99F2 /* WebPreviewAPIClient.swift */; };
 		84E53903242E2972002F99F2 /* InstantExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E538FD242E2972002F99F2 /* InstantExample.swift */; };
 		84E53904242E2972002F99F2 /* InstantDocumentPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E538FE242E2972002F99F2 /* InstantDocumentPresenter.swift */; };
 		84E53905242E2972002F99F2 /* InstantDocumentInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E538FF242E2972002F99F2 /* InstantDocumentInfo.swift */; };
 		84E53906242E2972002F99F2 /* InstantDocumentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E53900242E2972002F99F2 /* InstantDocumentViewController.swift */; };
 		84E5391F242E2A5C002F99F2 /* UIViewController+PSCFrontmost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E5391E242E2A5C002F99F2 /* UIViewController+PSCFrontmost.swift */; };
+		84F455972434D68A00DFFCCC /* WebExamplesAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F455962434D68A00DFFCCC /* WebExamplesAPIClient.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,7 +41,7 @@
 		00E356EE1AD99517003FC87E /* NativeCatalogTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NativeCatalogTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* NativeCatalogTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NativeCatalogTests.m; sourceTree = "<group>"; };
-		0ADA4E810EE2E6FAD4A3FD88 /* Pods-NativeCatalogTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NativeCatalogTests.release.xcconfig"; path = "Target Support Files/Pods-NativeCatalogTests/Pods-NativeCatalogTests.release.xcconfig"; sourceTree = "<group>"; };
+		1105704D4849AC5DB8933C8B /* Pods-NativeCatalogTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NativeCatalogTests.release.xcconfig"; path = "Target Support Files/Pods-NativeCatalogTests/Pods-NativeCatalogTests.release.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* NativeCatalog.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NativeCatalog.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = NativeCatalog/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = NativeCatalog/AppDelegate.m; sourceTree = "<group>"; };
@@ -49,8 +49,7 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = NativeCatalog/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = NativeCatalog/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = NativeCatalog/main.m; sourceTree = "<group>"; };
-		67D4656F82A81B754BB705C8 /* libPods-NativeCatalogTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NativeCatalogTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		73BCAB27B09D1F33F42A31F4 /* Pods-NativeCatalog.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NativeCatalog.release.xcconfig"; path = "Target Support Files/Pods-NativeCatalog/Pods-NativeCatalog.release.xcconfig"; sourceTree = "<group>"; };
+		396A8C1511F4924BA0A1E490 /* Pods-NativeCatalogTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NativeCatalogTests.debug.xcconfig"; path = "Target Support Files/Pods-NativeCatalogTests/Pods-NativeCatalogTests.debug.xcconfig"; sourceTree = "<group>"; };
 		844D64BE2375A9FE004E70D2 /* CustomPdfView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomPdfView.h; sourceTree = "<group>"; };
 		844D64BF2375A9FE004E70D2 /* CustomPdfView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CustomPdfView.m; sourceTree = "<group>"; };
 		844D64C12375AA44004E70D2 /* CustomPdfViewManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomPdfViewManager.h; sourceTree = "<group>"; };
@@ -58,17 +57,18 @@
 		844D64E52375B5FC004E70D2 /* PDFs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = PDFs; path = ../../PDFs; sourceTree = "<group>"; };
 		84E538FA242E2971002F99F2 /* NativeCatalog-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NativeCatalog-Bridging-Header.h"; sourceTree = "<group>"; };
 		84E538FB242E2972002F99F2 /* ScannerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ScannerViewController.swift; path = InstantExample/ScannerViewController.swift; sourceTree = SOURCE_ROOT; };
-		84E538FC242E2972002F99F2 /* WebPreviewAPIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WebPreviewAPIClient.swift; path = InstantExample/WebPreviewAPIClient.swift; sourceTree = SOURCE_ROOT; };
 		84E538FD242E2972002F99F2 /* InstantExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InstantExample.swift; path = InstantExample/InstantExample.swift; sourceTree = SOURCE_ROOT; };
 		84E538FE242E2972002F99F2 /* InstantDocumentPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InstantDocumentPresenter.swift; path = InstantExample/InstantDocumentPresenter.swift; sourceTree = SOURCE_ROOT; };
 		84E538FF242E2972002F99F2 /* InstantDocumentInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InstantDocumentInfo.swift; path = InstantExample/InstantDocumentInfo.swift; sourceTree = SOURCE_ROOT; };
 		84E53900242E2972002F99F2 /* InstantDocumentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InstantDocumentViewController.swift; path = InstantExample/InstantDocumentViewController.swift; sourceTree = SOURCE_ROOT; };
 		84E5391E242E2A5C002F99F2 /* UIViewController+PSCFrontmost.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIViewController+PSCFrontmost.swift"; path = "NativeCatalog/InstantExample/UIViewController+PSCFrontmost.swift"; sourceTree = SOURCE_ROOT; };
-		90AB00B79228B7BE8CFBB444 /* Pods-NativeCatalogTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NativeCatalogTests.debug.xcconfig"; path = "Target Support Files/Pods-NativeCatalogTests/Pods-NativeCatalogTests.debug.xcconfig"; sourceTree = "<group>"; };
-		B068A47725170C7A2100EE53 /* libPods-NativeCatalog.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NativeCatalog.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		E9DEF420A1F14ED4D79D10B7 /* Pods-NativeCatalog.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NativeCatalog.debug.xcconfig"; path = "Target Support Files/Pods-NativeCatalog/Pods-NativeCatalog.debug.xcconfig"; sourceTree = "<group>"; };
+		84F455962434D68A00DFFCCC /* WebExamplesAPIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WebExamplesAPIClient.swift; path = InstantExample/WebExamplesAPIClient.swift; sourceTree = SOURCE_ROOT; };
+		D3645470FDC1D2846E8C6A15 /* libPods-NativeCatalogTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NativeCatalogTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E6B9903E5A6F6239013AC3FB /* libPods-NativeCatalog.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NativeCatalog.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		EB96BC1AD898FD7F63559F12 /* Pods-NativeCatalog.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NativeCatalog.debug.xcconfig"; path = "Target Support Files/Pods-NativeCatalog/Pods-NativeCatalog.debug.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
+		F44E216A406398F13D80D322 /* Pods-NativeCatalog.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NativeCatalog.release.xcconfig"; path = "Target Support Files/Pods-NativeCatalog/Pods-NativeCatalog.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -76,7 +76,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4C20D1CACDACD8BD8B8DDD6A /* libPods-NativeCatalogTests.a in Frameworks */,
+				5791F4E044E07A89757F0251 /* libPods-NativeCatalogTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -84,7 +84,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				35C3D672073CC7D4C99F4A95 /* libPods-NativeCatalog.a in Frameworks */,
+				2AD52A55D07643AD7BFAA381 /* libPods-NativeCatalog.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -128,8 +128,8 @@
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
 				ED2971642150620600B7C4FE /* JavaScriptCore.framework */,
-				B068A47725170C7A2100EE53 /* libPods-NativeCatalog.a */,
-				67D4656F82A81B754BB705C8 /* libPods-NativeCatalogTests.a */,
+				E6B9903E5A6F6239013AC3FB /* libPods-NativeCatalog.a */,
+				D3645470FDC1D2846E8C6A15 /* libPods-NativeCatalogTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -188,8 +188,8 @@
 				84E53900242E2972002F99F2 /* InstantDocumentViewController.swift */,
 				84E538FD242E2972002F99F2 /* InstantExample.swift */,
 				84E538FB242E2972002F99F2 /* ScannerViewController.swift */,
+				84F455962434D68A00DFFCCC /* WebExamplesAPIClient.swift */,
 				84E5391E242E2A5C002F99F2 /* UIViewController+PSCFrontmost.swift */,
-				84E538FC242E2972002F99F2 /* WebPreviewAPIClient.swift */,
 			);
 			path = InstantExample;
 			sourceTree = "<group>";
@@ -197,10 +197,10 @@
 		E20636F4482E38B1DB5E29B7 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				E9DEF420A1F14ED4D79D10B7 /* Pods-NativeCatalog.debug.xcconfig */,
-				73BCAB27B09D1F33F42A31F4 /* Pods-NativeCatalog.release.xcconfig */,
-				90AB00B79228B7BE8CFBB444 /* Pods-NativeCatalogTests.debug.xcconfig */,
-				0ADA4E810EE2E6FAD4A3FD88 /* Pods-NativeCatalogTests.release.xcconfig */,
+				EB96BC1AD898FD7F63559F12 /* Pods-NativeCatalog.debug.xcconfig */,
+				F44E216A406398F13D80D322 /* Pods-NativeCatalog.release.xcconfig */,
+				396A8C1511F4924BA0A1E490 /* Pods-NativeCatalogTests.debug.xcconfig */,
+				1105704D4849AC5DB8933C8B /* Pods-NativeCatalogTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -212,7 +212,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "NativeCatalogTests" */;
 			buildPhases = (
-				24CECAA39128546E013EBAE9 /* [CP] Check Pods Manifest.lock */,
+				D212507043B3A93AC75A1A74 /* [CP] Check Pods Manifest.lock */,
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
@@ -231,13 +231,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "NativeCatalog" */;
 			buildPhases = (
-				BF195BA114F5DCB7F9302535 /* [CP] Check Pods Manifest.lock */,
+				34456C36ED5A4F745E28E799 /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				122E04F745F185A0FAFA3630 /* [CP] Embed Pods Frameworks */,
+				A55FE3DA6D56DB9652C17360 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -320,7 +320,29 @@
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
 		};
-		122E04F745F185A0FAFA3630 /* [CP] Embed Pods Frameworks */ = {
+		34456C36ED5A4F745E28E799 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-NativeCatalog-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A55FE3DA6D56DB9652C17360 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -348,7 +370,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-NativeCatalog/Pods-NativeCatalog-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		24CECAA39128546E013EBAE9 /* [CP] Check Pods Manifest.lock */ = {
+		D212507043B3A93AC75A1A74 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -364,28 +386,6 @@
 			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-NativeCatalogTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		BF195BA114F5DCB7F9302535 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-NativeCatalog-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -429,10 +429,10 @@
 				84E53903242E2972002F99F2 /* InstantExample.swift in Sources */,
 				84E53904242E2972002F99F2 /* InstantDocumentPresenter.swift in Sources */,
 				844D64C32375AA44004E70D2 /* CustomPdfViewManager.m in Sources */,
+				84F455972434D68A00DFFCCC /* WebExamplesAPIClient.swift in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 				84E53906242E2972002F99F2 /* InstantDocumentViewController.swift in Sources */,
-				84E53902242E2972002F99F2 /* WebPreviewAPIClient.swift in Sources */,
 				84E53905242E2972002F99F2 /* InstantDocumentInfo.swift in Sources */,
 				84E5391F242E2A5C002F99F2 /* UIViewController+PSCFrontmost.swift in Sources */,
 				84E53901242E2972002F99F2 /* ScannerViewController.swift in Sources */,
@@ -465,7 +465,7 @@
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 90AB00B79228B7BE8CFBB444 /* Pods-NativeCatalogTests.debug.xcconfig */;
+			baseConfigurationReference = 396A8C1511F4924BA0A1E490 /* Pods-NativeCatalogTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -489,7 +489,7 @@
 		};
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0ADA4E810EE2E6FAD4A3FD88 /* Pods-NativeCatalogTests.release.xcconfig */;
+			baseConfigurationReference = 1105704D4849AC5DB8933C8B /* Pods-NativeCatalogTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -510,13 +510,14 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E9DEF420A1F14ED4D79D10B7 /* Pods-NativeCatalog.debug.xcconfig */;
+			baseConfigurationReference = EB96BC1AD898FD7F63559F12 /* Pods-NativeCatalog.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = NativeCatalog/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
@@ -536,12 +537,13 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 73BCAB27B09D1F33F42A31F4 /* Pods-NativeCatalog.release.xcconfig */;
+			baseConfigurationReference = F44E216A406398F13D80D322 /* Pods-NativeCatalog.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = NativeCatalog/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (

--- a/samples/NativeCatalog/ios/NativeCatalog.xcodeproj/project.pbxproj
+++ b/samples/NativeCatalog/ios/NativeCatalog.xcodeproj/project.pbxproj
@@ -12,11 +12,18 @@
 		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		35C3D672073CC7D4C99F4A95 /* libPods-NativeCatalog.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B068A47725170C7A2100EE53 /* libPods-NativeCatalog.a */; };
+		4C20D1CACDACD8BD8B8DDD6A /* libPods-NativeCatalogTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 67D4656F82A81B754BB705C8 /* libPods-NativeCatalogTests.a */; };
 		844D64C02375A9FE004E70D2 /* CustomPdfView.m in Sources */ = {isa = PBXBuildFile; fileRef = 844D64BF2375A9FE004E70D2 /* CustomPdfView.m */; };
 		844D64C32375AA44004E70D2 /* CustomPdfViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 844D64C22375AA44004E70D2 /* CustomPdfViewManager.m */; };
 		844D64E62375B5FC004E70D2 /* PDFs in Resources */ = {isa = PBXBuildFile; fileRef = 844D64E52375B5FC004E70D2 /* PDFs */; };
-		F8DFCBFB8710295245046929 /* libPods-NativeCatalogTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F15CF991B34DB7DCB97ACC62 /* libPods-NativeCatalogTests.a */; };
-		F967B496800DA1257254229A /* libPods-NativeCatalog.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DD2215DAF6DA49603313B59 /* libPods-NativeCatalog.a */; };
+		84E53901242E2972002F99F2 /* ScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E538FB242E2972002F99F2 /* ScannerViewController.swift */; };
+		84E53902242E2972002F99F2 /* WebPreviewAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E538FC242E2972002F99F2 /* WebPreviewAPIClient.swift */; };
+		84E53903242E2972002F99F2 /* InstantExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E538FD242E2972002F99F2 /* InstantExample.swift */; };
+		84E53904242E2972002F99F2 /* InstantDocumentPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E538FE242E2972002F99F2 /* InstantDocumentPresenter.swift */; };
+		84E53905242E2972002F99F2 /* InstantDocumentInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E538FF242E2972002F99F2 /* InstantDocumentInfo.swift */; };
+		84E53906242E2972002F99F2 /* InstantDocumentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E53900242E2972002F99F2 /* InstantDocumentViewController.swift */; };
+		84E5391F242E2A5C002F99F2 /* UIViewController+PSCFrontmost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E5391E242E2A5C002F99F2 /* UIViewController+PSCFrontmost.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -34,6 +41,7 @@
 		00E356EE1AD99517003FC87E /* NativeCatalogTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NativeCatalogTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* NativeCatalogTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NativeCatalogTests.m; sourceTree = "<group>"; };
+		0ADA4E810EE2E6FAD4A3FD88 /* Pods-NativeCatalogTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NativeCatalogTests.release.xcconfig"; path = "Target Support Files/Pods-NativeCatalogTests/Pods-NativeCatalogTests.release.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* NativeCatalog.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NativeCatalog.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = NativeCatalog/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = NativeCatalog/AppDelegate.m; sourceTree = "<group>"; };
@@ -41,19 +49,26 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = NativeCatalog/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = NativeCatalog/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = NativeCatalog/main.m; sourceTree = "<group>"; };
+		67D4656F82A81B754BB705C8 /* libPods-NativeCatalogTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NativeCatalogTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		73BCAB27B09D1F33F42A31F4 /* Pods-NativeCatalog.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NativeCatalog.release.xcconfig"; path = "Target Support Files/Pods-NativeCatalog/Pods-NativeCatalog.release.xcconfig"; sourceTree = "<group>"; };
 		844D64BE2375A9FE004E70D2 /* CustomPdfView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomPdfView.h; sourceTree = "<group>"; };
 		844D64BF2375A9FE004E70D2 /* CustomPdfView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CustomPdfView.m; sourceTree = "<group>"; };
 		844D64C12375AA44004E70D2 /* CustomPdfViewManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomPdfViewManager.h; sourceTree = "<group>"; };
 		844D64C22375AA44004E70D2 /* CustomPdfViewManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CustomPdfViewManager.m; sourceTree = "<group>"; };
 		844D64E52375B5FC004E70D2 /* PDFs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = PDFs; path = ../../PDFs; sourceTree = "<group>"; };
-		8DD2215DAF6DA49603313B59 /* libPods-NativeCatalog.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NativeCatalog.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		B5A6A4743449251243796043 /* Pods-NativeCatalog.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NativeCatalog.debug.xcconfig"; path = "Target Support Files/Pods-NativeCatalog/Pods-NativeCatalog.debug.xcconfig"; sourceTree = "<group>"; };
-		CE797DAB3B2B01E88741C559 /* Pods-NativeCatalogTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NativeCatalogTests.release.xcconfig"; path = "Target Support Files/Pods-NativeCatalogTests/Pods-NativeCatalogTests.release.xcconfig"; sourceTree = "<group>"; };
+		84E538FA242E2971002F99F2 /* NativeCatalog-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NativeCatalog-Bridging-Header.h"; sourceTree = "<group>"; };
+		84E538FB242E2972002F99F2 /* ScannerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ScannerViewController.swift; path = InstantExample/ScannerViewController.swift; sourceTree = SOURCE_ROOT; };
+		84E538FC242E2972002F99F2 /* WebPreviewAPIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WebPreviewAPIClient.swift; path = InstantExample/WebPreviewAPIClient.swift; sourceTree = SOURCE_ROOT; };
+		84E538FD242E2972002F99F2 /* InstantExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InstantExample.swift; path = InstantExample/InstantExample.swift; sourceTree = SOURCE_ROOT; };
+		84E538FE242E2972002F99F2 /* InstantDocumentPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InstantDocumentPresenter.swift; path = InstantExample/InstantDocumentPresenter.swift; sourceTree = SOURCE_ROOT; };
+		84E538FF242E2972002F99F2 /* InstantDocumentInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InstantDocumentInfo.swift; path = InstantExample/InstantDocumentInfo.swift; sourceTree = SOURCE_ROOT; };
+		84E53900242E2972002F99F2 /* InstantDocumentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InstantDocumentViewController.swift; path = InstantExample/InstantDocumentViewController.swift; sourceTree = SOURCE_ROOT; };
+		84E5391E242E2A5C002F99F2 /* UIViewController+PSCFrontmost.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIViewController+PSCFrontmost.swift"; path = "NativeCatalog/InstantExample/UIViewController+PSCFrontmost.swift"; sourceTree = SOURCE_ROOT; };
+		90AB00B79228B7BE8CFBB444 /* Pods-NativeCatalogTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NativeCatalogTests.debug.xcconfig"; path = "Target Support Files/Pods-NativeCatalogTests/Pods-NativeCatalogTests.debug.xcconfig"; sourceTree = "<group>"; };
+		B068A47725170C7A2100EE53 /* libPods-NativeCatalog.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NativeCatalog.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E9DEF420A1F14ED4D79D10B7 /* Pods-NativeCatalog.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NativeCatalog.debug.xcconfig"; path = "Target Support Files/Pods-NativeCatalog/Pods-NativeCatalog.debug.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
-		F15CF991B34DB7DCB97ACC62 /* libPods-NativeCatalogTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NativeCatalogTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		F83C3648809B4EBD4D09BF5B /* Pods-NativeCatalog.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NativeCatalog.release.xcconfig"; path = "Target Support Files/Pods-NativeCatalog/Pods-NativeCatalog.release.xcconfig"; sourceTree = "<group>"; };
-		FBEC3D241B9AF7D25A2E8A50 /* Pods-NativeCatalogTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NativeCatalogTests.debug.xcconfig"; path = "Target Support Files/Pods-NativeCatalogTests/Pods-NativeCatalogTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -61,7 +76,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F8DFCBFB8710295245046929 /* libPods-NativeCatalogTests.a in Frameworks */,
+				4C20D1CACDACD8BD8B8DDD6A /* libPods-NativeCatalogTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -69,7 +84,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F967B496800DA1257254229A /* libPods-NativeCatalog.a in Frameworks */,
+				35C3D672073CC7D4C99F4A95 /* libPods-NativeCatalog.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -113,8 +128,8 @@
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
 				ED2971642150620600B7C4FE /* JavaScriptCore.framework */,
-				8DD2215DAF6DA49603313B59 /* libPods-NativeCatalog.a */,
-				F15CF991B34DB7DCB97ACC62 /* libPods-NativeCatalogTests.a */,
+				B068A47725170C7A2100EE53 /* libPods-NativeCatalog.a */,
+				67D4656F82A81B754BB705C8 /* libPods-NativeCatalogTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -158,18 +173,34 @@
 				844D64BF2375A9FE004E70D2 /* CustomPdfView.m */,
 				844D64C12375AA44004E70D2 /* CustomPdfViewManager.h */,
 				844D64C22375AA44004E70D2 /* CustomPdfViewManager.m */,
+				84E53907242E2981002F99F2 /* InstantExample */,
+				84E538FA242E2971002F99F2 /* NativeCatalog-Bridging-Header.h */,
 			);
 			name = Examples;
 			path = NativeCatalog/Examples;
 			sourceTree = "<group>";
 		};
+		84E53907242E2981002F99F2 /* InstantExample */ = {
+			isa = PBXGroup;
+			children = (
+				84E538FF242E2972002F99F2 /* InstantDocumentInfo.swift */,
+				84E538FE242E2972002F99F2 /* InstantDocumentPresenter.swift */,
+				84E53900242E2972002F99F2 /* InstantDocumentViewController.swift */,
+				84E538FD242E2972002F99F2 /* InstantExample.swift */,
+				84E538FB242E2972002F99F2 /* ScannerViewController.swift */,
+				84E5391E242E2A5C002F99F2 /* UIViewController+PSCFrontmost.swift */,
+				84E538FC242E2972002F99F2 /* WebPreviewAPIClient.swift */,
+			);
+			path = InstantExample;
+			sourceTree = "<group>";
+		};
 		E20636F4482E38B1DB5E29B7 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				B5A6A4743449251243796043 /* Pods-NativeCatalog.debug.xcconfig */,
-				F83C3648809B4EBD4D09BF5B /* Pods-NativeCatalog.release.xcconfig */,
-				FBEC3D241B9AF7D25A2E8A50 /* Pods-NativeCatalogTests.debug.xcconfig */,
-				CE797DAB3B2B01E88741C559 /* Pods-NativeCatalogTests.release.xcconfig */,
+				E9DEF420A1F14ED4D79D10B7 /* Pods-NativeCatalog.debug.xcconfig */,
+				73BCAB27B09D1F33F42A31F4 /* Pods-NativeCatalog.release.xcconfig */,
+				90AB00B79228B7BE8CFBB444 /* Pods-NativeCatalogTests.debug.xcconfig */,
+				0ADA4E810EE2E6FAD4A3FD88 /* Pods-NativeCatalogTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -181,7 +212,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "NativeCatalogTests" */;
 			buildPhases = (
-				50C90141EA813110329DA66A /* [CP] Check Pods Manifest.lock */,
+				24CECAA39128546E013EBAE9 /* [CP] Check Pods Manifest.lock */,
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
@@ -200,13 +231,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "NativeCatalog" */;
 			buildPhases = (
-				F6B2621DF07D9775AAD826AC /* [CP] Check Pods Manifest.lock */,
+				BF195BA114F5DCB7F9302535 /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				AA345863E5F909B3363D8BE6 /* [CP] Embed Pods Frameworks */,
+				122E04F745F185A0FAFA3630 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -229,6 +260,9 @@
 					00E356ED1AD99517003FC87E = {
 						CreatedOnToolsVersion = 6.2;
 						TestTargetID = 13B07F861A680F5B00A75B9A;
+					};
+					13B07F861A680F5B00A75B9A = {
+						LastSwiftMigration = 1140;
 					};
 				};
 			};
@@ -286,7 +320,35 @@
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
 		};
-		50C90141EA813110329DA66A /* [CP] Check Pods Manifest.lock */ = {
+		122E04F745F185A0FAFA3630 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-NativeCatalog/Pods-NativeCatalog-frameworks.sh",
+				"${PODS_ROOT}/Instant/Instant.framework",
+				"${PODS_ROOT}/Instant/Instant.framework.dSYM",
+				"${PODS_ROOT}/PSPDFKit/PSPDFKit.framework",
+				"${PODS_ROOT}/PSPDFKit/PSPDFKit.framework.dSYM",
+				"${PODS_ROOT}/PSPDFKit/PSPDFKitUI.framework",
+				"${PODS_ROOT}/PSPDFKit/PSPDFKitUI.framework.dSYM",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Instant.framework",
+				"${DWARF_DSYM_FOLDER_PATH}/Instant.framework.dSYM",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PSPDFKit.framework",
+				"${DWARF_DSYM_FOLDER_PATH}/PSPDFKit.framework.dSYM",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PSPDFKitUI.framework",
+				"${DWARF_DSYM_FOLDER_PATH}/PSPDFKitUI.framework.dSYM",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-NativeCatalog/Pods-NativeCatalog-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		24CECAA39128546E013EBAE9 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -308,31 +370,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		AA345863E5F909B3363D8BE6 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-NativeCatalog/Pods-NativeCatalog-frameworks.sh",
-				"${PODS_ROOT}/PSPDFKit/PSPDFKit.framework",
-				"${PODS_ROOT}/PSPDFKit/PSPDFKit.framework.dSYM",
-				"${PODS_ROOT}/PSPDFKit/PSPDFKitUI.framework",
-				"${PODS_ROOT}/PSPDFKit/PSPDFKitUI.framework.dSYM",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PSPDFKit.framework",
-				"${DWARF_DSYM_FOLDER_PATH}/PSPDFKit.framework.dSYM",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PSPDFKitUI.framework",
-				"${DWARF_DSYM_FOLDER_PATH}/PSPDFKitUI.framework.dSYM",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-NativeCatalog/Pods-NativeCatalog-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		F6B2621DF07D9775AAD826AC /* [CP] Check Pods Manifest.lock */ = {
+		BF195BA114F5DCB7F9302535 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -388,9 +426,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				84E53903242E2972002F99F2 /* InstantExample.swift in Sources */,
+				84E53904242E2972002F99F2 /* InstantDocumentPresenter.swift in Sources */,
 				844D64C32375AA44004E70D2 /* CustomPdfViewManager.m in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
+				84E53906242E2972002F99F2 /* InstantDocumentViewController.swift in Sources */,
+				84E53902242E2972002F99F2 /* WebPreviewAPIClient.swift in Sources */,
+				84E53905242E2972002F99F2 /* InstantDocumentInfo.swift in Sources */,
+				84E5391F242E2A5C002F99F2 /* UIViewController+PSCFrontmost.swift in Sources */,
+				84E53901242E2972002F99F2 /* ScannerViewController.swift in Sources */,
 				844D64C02375A9FE004E70D2 /* CustomPdfView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -420,8 +465,9 @@
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FBEC3D241B9AF7D25A2E8A50 /* Pods-NativeCatalogTests.debug.xcconfig */;
+			baseConfigurationReference = 90AB00B79228B7BE8CFBB444 /* Pods-NativeCatalogTests.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -443,8 +489,9 @@
 		};
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CE797DAB3B2B01E88741C559 /* Pods-NativeCatalogTests.release.xcconfig */;
+			baseConfigurationReference = 0ADA4E810EE2E6FAD4A3FD88 /* Pods-NativeCatalogTests.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
 				INFOPLIST_FILE = NativeCatalogTests/Info.plist;
@@ -463,9 +510,11 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B5A6A4743449251243796043 /* Pods-NativeCatalog.debug.xcconfig */;
+			baseConfigurationReference = E9DEF420A1F14ED4D79D10B7 /* Pods-NativeCatalog.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
 				INFOPLIST_FILE = NativeCatalog/Info.plist;
@@ -477,6 +526,9 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.pspdfkit.example.NativeCatalog;
 				PRODUCT_NAME = NativeCatalog;
+				SWIFT_OBJC_BRIDGING_HEADER = "NativeCatalog/Examples/NativeCatalog-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -484,9 +536,11 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F83C3648809B4EBD4D09BF5B /* Pods-NativeCatalog.release.xcconfig */;
+			baseConfigurationReference = 73BCAB27B09D1F33F42A31F4 /* Pods-NativeCatalog.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = NativeCatalog/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -497,6 +551,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.pspdfkit.example.NativeCatalog;
 				PRODUCT_NAME = NativeCatalog;
+				SWIFT_OBJC_BRIDGING_HEADER = "NativeCatalog/Examples/NativeCatalog-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};

--- a/samples/NativeCatalog/ios/NativeCatalog/Examples/CustomPdfView.h
+++ b/samples/NativeCatalog/ios/NativeCatalog/Examples/CustomPdfView.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)startSigning;
 - (BOOL)createWatermarkAndReloadData:(BOOL)reloadData;
+- (BOOL)presentInstantExample;
 
 @end
 

--- a/samples/NativeCatalog/ios/NativeCatalog/Examples/CustomPdfView.m
+++ b/samples/NativeCatalog/ios/NativeCatalog/Examples/CustomPdfView.m
@@ -9,6 +9,7 @@
 
 #import "CustomPdfView.h"
 #import <React/RCTUtils.h>
+#import "NativeCatalog-Swift.h"
 
 @interface CustomPdfView()<PSPDFSignatureViewControllerDelegate>
 @property (nonatomic, nullable) UIViewController *topController;
@@ -47,9 +48,8 @@
 
   if (self.pdfController.configuration.useParentNavigationBar) {
     self.topController = self.pdfController;
-
   } else {
-    self.topController = [[PSPDFNavigationController alloc] initWithRootViewController:self.pdfController];;
+    self.topController = [[PSPDFNavigationController alloc] initWithRootViewController:self.pdfController];
   }
 
   UIView *topControllerView = self.topController.view;
@@ -187,6 +187,20 @@
     [_pdfController reloadData];
   }
   return YES;
+}
+
+- (BOOL)presentInstantExample {
+  UIViewController *presentingViewController = RCTPresentedViewController();
+  InstantExampleViewController *instantExampleViewController = [[InstantExampleViewController alloc] init];
+  self.topController = [[PSPDFNavigationController alloc] initWithRootViewController:instantExampleViewController];
+  self.topController.modalPresentationStyle = UIModalPresentationFullScreen;
+  instantExampleViewController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithImage:[PSPDFKitGlobal imageNamed:@"x"] style:UIBarButtonItemStylePlain target:self action:@selector(closeInstantExampleButtonPressed:)];
+  [presentingViewController presentViewController:self.topController animated:YES completion:NULL];
+  return YES;
+}
+
+- (void)closeInstantExampleButtonPressed:(nullable id)sender {
+  [self.topController dismissViewControllerAnimated:YES completion:NULL];
 }
 
 @end

--- a/samples/NativeCatalog/ios/NativeCatalog/Examples/CustomPdfViewManager.m
+++ b/samples/NativeCatalog/ios/NativeCatalog/Examples/CustomPdfViewManager.m
@@ -59,6 +59,19 @@ RCT_EXPORT_METHOD(createWatermark:(nonnull NSNumber *)reactTag resolver:(RCTProm
   });
 }
 
+RCT_EXPORT_METHOD(presentInstantExample:(nonnull NSNumber *)reactTag resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    CustomPdfView *component = (CustomPdfView *)[self.bridge.uiManager viewForReactTag:reactTag];
+    NSError *error;
+    BOOL success = [component presentInstantExample];
+    if (success) {
+      resolve(@(success));
+    } else {
+      reject(@"error", @"Failed to present Instant Example.", error);
+    }
+  });
+}
+
 - (UIView *)view {
   return [[CustomPdfView alloc] init];
 }

--- a/samples/NativeCatalog/ios/NativeCatalog/Examples/NativeCatalog-Bridging-Header.h
+++ b/samples/NativeCatalog/ios/NativeCatalog/Examples/NativeCatalog-Bridging-Header.h
@@ -1,0 +1,7 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+@import UIKit;
+@import PSPDFKit;
+@import PSPDFKitUI;

--- a/samples/NativeCatalog/ios/NativeCatalog/Info.plist
+++ b/samples/NativeCatalog/ios/NativeCatalog/Info.plist
@@ -37,8 +37,14 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string>Pictures captured with the camera can be added to the document as image annotations.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Recording sound annotations requires the microphone.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Pictures from the photo library can be added to the document as image annotations.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/samples/NativeCatalog/ios/NativeCatalog/InstantExample/InstantDocumentInfo.swift
+++ b/samples/NativeCatalog/ios/NativeCatalog/InstantExample/InstantDocumentInfo.swift
@@ -1,0 +1,58 @@
+//
+//  InstantDocumentInfo.swift
+//  PSPDFKit
+//
+//  Copyright © 2017-2020 PSPDFKit GmbH. All rights reserved.
+//
+//  THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY INTERNATIONAL COPYRIGHT LAW
+//  AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT.
+//  UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
+//  This notice may not be removed from this file.
+//
+
+/// The response from the PSPDFKit for Web examples server API that may be used to load a document layer with Instant.
+struct InstantDocumentInfo {
+    let serverURL: URL
+    let url: URL
+    let jwt: String
+}
+
+extension InstantDocumentInfo: Equatable {
+    public static func == (lhs: InstantDocumentInfo, rhs: InstantDocumentInfo) -> Bool {
+        return lhs.serverURL == rhs.serverURL && lhs.url == rhs.url && lhs.jwt == rhs.jwt
+    }
+}
+
+extension InstantDocumentInfo {
+    enum JSONKeys: String {
+        case serverUrl, url, documentId, jwt
+    }
+
+    init?(json: Any) {
+        guard let dictionary = json as? [String: Any] else {
+            return nil
+        }
+
+        guard let serverUrlString = dictionary[JSONKeys.serverUrl.rawValue] as? String else {
+            return nil
+        }
+
+        guard let serverURL = URL(string: serverUrlString) else {
+            return nil
+        }
+
+        guard let urlString = dictionary[JSONKeys.url.rawValue] as? String else {
+            return nil
+        }
+
+        guard let url = URL(string: urlString) else {
+            return nil
+        }
+
+        guard let jwt = dictionary[JSONKeys.jwt.rawValue] as? String else {
+            return nil
+        }
+
+        self.init(serverURL: serverURL, url: url, jwt: jwt)
+    }
+}

--- a/samples/NativeCatalog/ios/NativeCatalog/InstantExample/InstantDocumentPresenter.swift
+++ b/samples/NativeCatalog/ios/NativeCatalog/InstantExample/InstantDocumentPresenter.swift
@@ -1,0 +1,110 @@
+//
+//  Copyright © 2018-2020 PSPDFKit GmbH. All rights reserved.
+//
+//  THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY INTERNATIONAL COPYRIGHT LAW
+//  AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT.
+//  UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
+//  This notice may not be removed from this file.
+//
+
+import PSPDFKitUI
+
+/**
+ Connects to our public PSPDFKit for Web examples server to present documents managed by PSPDFKit Instant.
+ This is decoupled from any view controller in order to support loading documents by opening URLs.
+ */
+public class InstantDocumentPresenter {
+    /**
+     Interfaces with our Web examples server to create and access documents.
+     In your own app you would connect to your own server backend to get Instant document identifiers and authentication tokens.
+     */
+    private lazy var apiClient = WebExamplesAPIClient(presentingViewController: presentingViewController)
+
+    /// View controller that can present other view controllers.
+    private weak var presentingViewController: UIViewController?
+
+    /// Initialize a document presenter with a view controller that can present other view controllers.
+    public init(presentingViewController: UIViewController) {
+        self.presentingViewController = presentingViewController
+    }
+
+    /// Tries to create a new Instant session.
+    public func createNewSession() {
+        loadSession(loadingMessage: "Creating") { completion in
+            self.apiClient.createNewSession(completion: completion)
+        }
+    }
+
+    /**
+     Tries to join an existing Instant session or shows an alert on failure.
+
+     - Parameter urlString: An Instant document URL scanned from a barcode or entered by the user.
+     */
+    public func joinExistingSession(withURL urlString: String) {
+        guard let url = URL(string: urlString) else {
+            showAlert(withTitle: "Couldn’t Join Group", message: "This is not a link. Please enter an Instant document link.")
+            return
+        }
+
+        loadSession(loadingMessage: "Verifying") { completion in
+            self.apiClient.resolveExistingSessionURL(url, completion: completion)
+        }
+    }
+
+    /**
+     Loads an Instant session using the specified API call. The passed in closure should run an
+     asynchronous API call. That closure will be passed another closure to run on completion.
+     */
+    private func loadSession(loadingMessage: String, APICall: @escaping (@escaping WebExamplesAPIClient.CompletionHandler) -> Void) {
+        let progressHUDItem = StatusHUDItem.indeterminateProgress(withText: loadingMessage)
+        progressHUDItem.setHUDStyle(.black)
+
+        progressHUDItem.push(animated: true, on: presentingViewController?.view.window) {
+            APICall { result in
+                DispatchQueue.main.async {
+                    progressHUDItem.pop(animated: true, completion: nil)
+
+                    switch result {
+                    case let .success(documentInfo):
+                        do {
+                            try self.openDocument(with: documentInfo)
+                        } catch {
+                            self.showAlert(withTitle: "Couldn’t Set Up Instant", message: error.localizedDescription)
+                        }
+
+                    case .failure(WebExamplesAPIClient.Failure.cancelled):
+                        break // Do not show the alert if user cancelled the request themselves.
+
+                    case let .failure(otherError):
+                        self.showAlert(withTitle: "Couldn’t Get Instant Document Info", message: otherError.localizedDescription)
+                    }
+                }
+            }
+        }
+    }
+
+    private func openDocument(with info: InstantDocumentInfo) throws {
+        let instantViewController = try InstantDocumentViewController(documentInfo: info)
+
+        let navigationController = UINavigationController(rootViewController: instantViewController)
+        navigationController.modalPresentationStyle = .fullScreen
+
+        presentOnFrontmostViewController(navigationController)
+    }
+
+    private func showAlert(withTitle title: String, message: String) {
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: "OK", style: .cancel))
+
+        presentOnFrontmostViewController(alertController)
+    }
+
+    private func presentOnFrontmostViewController(_ viewController: UIViewController) {
+        guard let rootViewController = presentingViewController?.viewIfLoaded?.window?.rootViewController else {
+            print("Couldn’t show view controller because no root view controller was found.")
+            return
+        }
+
+        rootViewController.psc_frontmost.present(viewController, animated: true, completion: nil)
+    }
+}

--- a/samples/NativeCatalog/ios/NativeCatalog/InstantExample/InstantDocumentViewController.swift
+++ b/samples/NativeCatalog/ios/NativeCatalog/InstantExample/InstantDocumentViewController.swift
@@ -1,0 +1,135 @@
+//
+//  Copyright © 2019-2020 PSPDFKit GmbH. All rights reserved.
+//
+//  The PSPDFKit Sample applications are licensed with a modified BSD license.
+//  Please see License for details. This notice may not be removed from this file.
+//
+
+import Instant
+import PSPDFKit
+
+/**
+ Downloads and shows a document managed by Instant, and shows a
+ button to share the document URL so you can see Instant syncing.
+ */
+class InstantDocumentViewController: InstantViewController {
+    private let documentInfo: InstantDocumentInfo
+    private let client: InstantClient
+    private let documentDescriptor: InstantDocumentDescriptor
+
+    init(documentInfo: InstantDocumentInfo) throws {
+        /*
+         Create the Instant objects with the information from the PSPDFKit for Web examples server.
+
+         The `PSPDFDocument` you get from Instant does not retain the objects that create it,
+         so we need to keep references to the client and document descriptor otherwise with no
+         strong references they would deallocate and syncing would stop.
+         */
+        client = try InstantClient(serverURL: documentInfo.serverURL)
+
+        documentDescriptor = try client.documentDescriptor(forJWT: documentInfo.jwt)
+
+        // Store document info for sharing later.
+        self.documentInfo = documentInfo
+
+        // Tell Instant to download the document from Web examples server’s PSPDFKit Server instance.
+        do {
+            try documentDescriptor.download(usingJWT: documentInfo.jwt)
+        } catch InstantError.alreadyDownloaded {
+            // This is fine, we only have to reauthenticate. Any other errors are passed up.
+            documentDescriptor.reauthenticate(withJWT: documentInfo.jwt)
+        }
+
+        // Get the `PSPDFDocument` from Instant.
+        let pdfDocument = documentDescriptor.editableDocument
+
+        // Set the document on the `PSPDFInstantViewController` (the superclass) so it can show the download progress, and then show the document.
+        super.init(document: pdfDocument, configuration: PDFConfiguration {
+            $0.pageTransition = .scrollContinuous
+            $0.scrollDirection = .vertical
+        })
+
+        let collaborateItem = UIBarButtonItem(title: "Collaborate", style: .plain, target: self, action: #selector(showCollaborationOptions(_:)))
+        let barButtonItems = [collaborateItem, annotationButtonItem]
+        navigationItem.setRightBarButtonItems(barButtonItems, for: .document, animated: false)
+    }
+
+    @available(*, unavailable)
+    required init?(coder decoder: NSCoder) {
+        fatalError("init(coder:) is not supported.")
+    }
+
+    deinit {
+        do {
+            /*
+             Since this demo is ephemeral, clean up immediately.
+             Note that this also cancels syncing that is in-progress.
+             */
+            try documentDescriptor.removeLocalStorage()
+        } catch {
+            print("Could not remove Instant document storage: \(error)")
+        }
+    }
+
+    private let notificationNames: [Notification.Name] = [.PSPDFInstantDidFailDownload, .PSPDFInstantDidFailSyncing, .PSPDFInstantDidFailAuthentication, .PSPDFInstantDidFailReauthentication]
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        for name in notificationNames {
+            NotificationCenter.default.addObserver(self, selector: #selector(showError(notification:)), name: name, object: documentDescriptor)
+        }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        for name in notificationNames {
+            NotificationCenter.default.removeObserver(self, name: name, object: documentDescriptor)
+        }
+    }
+
+    @objc private func showError(notification: Notification) {
+        // Notifications from Instant will be posted on a background thread.
+        DispatchQueue.main.async {
+
+            let title: String
+            switch notification.name {
+            case .PSPDFInstantDidFailDownload:
+                title = "Couldn’t Download Document"
+            case .PSPDFInstantDidFailSyncing:
+                title = "Couldn’t Sync"
+            case .PSPDFInstantDidFailAuthentication:
+                title = "Couldn’t Authenticate"
+            case .PSPDFInstantDidFailReauthentication:
+                title = "Couldn’t Reauthenticate"
+            default:
+                fatalError("Unexpected notification name \(notification.name)")
+            }
+
+            let error = notification.userInfo?[PSPDFInstantErrorKey] as? NSError
+
+            let alertController = UIAlertController(title: title, message: error?.localizedDescription, preferredStyle: .alert)
+            alertController.addAction(UIAlertAction(title: "OK", style: .cancel))
+            self.psc_frontmost.present(alertController, animated: true, completion: nil)
+        }
+    }
+
+    @objc private func showCollaborationOptions(_ sender: UIBarButtonItem) {
+        let alertController = UIAlertController(title: documentInfo.url.absoluteString, message: nil, preferredStyle: .actionSheet)
+        alertController.popoverPresentationController?.barButtonItem = sender
+
+        alertController.addAction(UIAlertAction(title: "Open in Safari", style: .default, handler: { [unowned self] _ in
+            UIApplication.shared.open(self.documentInfo.url, options: [:], completionHandler: nil)
+        }))
+        alertController.addAction(UIAlertAction(title: "Share Document Link", style: .default, handler: { [unowned self] _ in
+            let activityViewController = UIActivityViewController(activityItems: [self.documentInfo.url], applicationActivities: nil)
+            activityViewController.popoverPresentationController?.barButtonItem = sender
+
+            self.present(activityViewController, animated: true)
+        }))
+        alertController.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+
+        present(alertController, animated: true)
+    }
+}

--- a/samples/NativeCatalog/ios/NativeCatalog/InstantExample/InstantExample.swift
+++ b/samples/NativeCatalog/ios/NativeCatalog/InstantExample/InstantExample.swift
@@ -1,0 +1,273 @@
+//
+//  Copyright © 2017-2020 PSPDFKit GmbH. All rights reserved.
+//
+//  The PSPDFKit Sample applications are licensed with a modified BSD license.
+//  Please see License for details. This notice may not be removed from this file.
+//
+
+import Instant
+
+/**
+ This example connects to our public PSPDFKit for Web examples server and downloads documents using PSPDFKit Instant.
+ You can then collaboratively annotate these documents using Instant.
+ Each document on the PSPDFKit for Web examples server can be accessed via its URL.
+
+ The example lets you either create a new collaboration group then share the URL,
+ or join an existing collaboration group by entering a URL.
+ To speed this up, the URL can be read from a QR code.
+
+ Other supported clients include:
+
+ - PSPDFKit Instant Live Demo: https://pspdfkit.com/instant/demo/
+ - PSPDFKit for Web examples: https://web-examples.pspdfkit.com
+ - PDF Viewer for iOS and Android: https://pdfviewer.io
+ - PSPDFKit Catalog example app for Android
+
+ As is usually the case with Instant, most of the code here deals with communicating with the
+ particular server backend (our Web examples server in this case), so is not particularly useful
+ as example code. The same applies to the other files in this folder.
+
+ The code actually interacting with the Instant framework API is in `InstantDocumentViewController.swift`.
+ */
+class InstantExample: Example {
+    override init() {
+        super.init()
+
+        title = "PSPDFKit Instant"
+        contentDescription = "Downloads a document for collaborative editing."
+        category = .top
+        priority = 2
+    }
+
+    override func invoke(with delegate: ExampleRunnerDelegate) -> UIViewController {
+        return InstantExampleViewController()
+    }
+}
+
+/// Shows UI to either start a new collaboration session or join an existing session.
+class InstantExampleViewController: UITableViewController {
+
+    private lazy var apiClient = WebExamplesAPIClient(presentingViewController: self)
+    private lazy var instantDocumentPresenter = InstantDocumentPresenter(presentingViewController: self)
+
+    /// A reference to the text field in the cell so it can be disabled when starting a new group to avoid duplicate network requests.
+    weak var codeTextField: UITextField?
+
+    init() {
+        super.init(style: .grouped)
+        title = "PSPDFKit Instant"
+
+        // Since this demo is ephemeral, we want to ensure we start with a clean slate each time.
+        // The InstantDocumentViewController tries to clean up when it deallocates but that can’t catch every case.
+        do {
+            try FileManager.default.removeItem(at: InstantClient.dataDirectory)
+        } catch {
+            switch error {
+            case CocoaError.fileNoSuchFile,
+                 CocoaError.fileReadNoSuchFile:
+                // If the directory does not exist, it is technically an error, but a happy one.
+                break
+            default:
+                print("Could not remove Instant data directory: \(error)")
+            }
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder decoder: NSCoder) {
+        fatalError("init(coder:) is not supported.")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        tableView.keyboardDismissMode = .onDrag
+        tableView.cellLayoutMarginsFollowReadableWidth = true
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: CellIdentifier.newGroup.rawValue)
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: CellIdentifier.scanCode.rawValue)
+        tableView.register(TextFieldCell.self, forCellReuseIdentifier: CellIdentifier.urlField.rawValue)
+    }
+
+    enum CellIdentifier: String {
+        case newGroup = "new group"
+        case scanCode = "scan code"
+        case urlField = "url field"
+    }
+
+    struct Row {
+        let identifier: CellIdentifier
+        let allowsHighlight: Bool
+    }
+
+    struct Section {
+        let header: String?
+        let rows: [Row]
+        let footer: String?
+    }
+
+    /// Data to show in the table view.
+    private let sections: [Section] = [
+        Section(header: "Seamless collaboration for PSPDFKit-powered apps", rows: [], footer: "The PSPDFKit SDKs support Instant out of the box. Just connect your app to an Instant server and document management and syncing is taken care of."),
+        Section(header: "Start a new group", rows: [Row(identifier: .newGroup, allowsHighlight: true)], footer: "Get a new document link, then collaborate by entering it in PSPDFKit Catalog on another device, or opening the document link in a web browser."),
+        Section(header: "Join a group", rows: [Row(identifier: .scanCode, allowsHighlight: true), Row(identifier: .urlField, allowsHighlight: false)], footer: "Scan or enter a document link from PDF Viewer or PSPDFKit Catalog on another device, or from a web browser showing pspdfkit.com/instant/demo or web-examples.pspdfkit.com."),
+    ]
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return sections.count
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return sections[section].rows.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = sections[indexPath.section].rows[indexPath.row]
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.identifier.rawValue, for: indexPath)
+
+        cell.textLabel?.textColor = tableView.tintColor
+        cell.textLabel?.font = UIFont.preferredFont(forTextStyle: .headline)
+
+        switch row.identifier {
+        case .newGroup:
+            cell.textLabel?.text = "Create Group"
+            return cell
+
+        case .scanCode:
+            cell.textLabel?.text = "Scan QR Code"
+            return cell
+
+        case .urlField:
+            let textField = (cell as! TextFieldCell).textField
+
+            codeTextField = textField
+
+            textField.delegate = self
+            return cell
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return sections[section].header
+    }
+
+    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return sections[section].footer
+    }
+
+    override func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
+        return sections[indexPath.section].rows[indexPath.row].allowsHighlight
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let rowId = sections[indexPath.section].rows[indexPath.row].identifier
+
+        switch rowId {
+        case .newGroup:
+            instantDocumentPresenter.createNewSession()
+        case .scanCode:
+            requestPermissionAndPresentScanner()
+        case .urlField:
+            fatalError("Shouldn’t be able to select URL field cell.")
+        }
+    }
+
+    private func requestPermissionAndPresentScanner() {
+        AVCaptureDevice.requestAccess(for: .video) { [weak self] (granted: Bool) -> Void in
+            DispatchQueue.main.async {
+                guard let self = self else {
+                    return
+                }
+                if granted {
+                    let scannerVC = ScannerViewController()
+                    scannerVC.delegate = self
+                    let navigationVC = UINavigationController(rootViewController: scannerVC)
+                    navigationVC.modalPresentationStyle = .fullScreen
+
+                    self.navigationController?.present(navigationVC, animated: true, completion: nil)
+                } else {
+                    self.tableView.selectRow(at: nil, animated: true, scrollPosition: .none)
+                    self.showError(withTitle: "Camera Access Needed", message: "To scan QR codes, enable camera access in the Settings app.")
+                }
+            }
+        }
+    }
+
+    private func showError(withTitle title: String, message: String) {
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: "OK", style: .cancel))
+
+        present(alertController, animated: true, completion: nil)
+    }
+}
+
+// MARK: - Text field delegate
+
+extension InstantExampleViewController: UITextFieldDelegate {
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        guard let text = textField.text else {
+            return false
+        }
+
+        instantDocumentPresenter.joinExistingSession(withURL: text)
+        return true
+    }
+}
+
+// MARK: - Scanner view controller delegate
+
+extension InstantExampleViewController: ScannerViewControllerDelegate {
+
+    func scannerViewController(_ scannerViewController: ScannerViewController, didFinishScanningWith result: BarcodeScanResult) {
+        if case .success(let barcode) = result {
+            codeTextField?.text = barcode
+        }
+
+        self.dismiss(animated: true) {
+            switch result {
+            case .success(let barcode):
+                self.instantDocumentPresenter.joinExistingSession(withURL: barcode)
+            case .failure(let errorMessage):
+                self.showError(withTitle: "Couldn’t Scan QR Code", message: errorMessage)
+            }
+        }
+    }
+}
+
+// MARK: -
+
+class TextFieldCell: UITableViewCell {
+    let textField = UITextField()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        textField.placeholder = "Or Enter Document Link"
+
+        textField.clearButtonMode = .always
+        textField.keyboardType = .alphabet
+        textField.autocorrectionType = .no
+        textField.autocapitalizationType = .none
+        textField.returnKeyType = .done
+
+        textField.font = UIFont.preferredFont(forTextStyle: .headline)
+
+        contentView.addSubview(textField)
+    }
+
+    required init?(coder decoder: NSCoder) {
+        fatalError("init(coder:) is not supported.")
+    }
+
+    override func sizeThatFits(_ size: CGSize) -> CGSize {
+        let availableWidth = size.width - layoutMargins.left - layoutMargins.right
+        let height = layoutMargins.top + textField.sizeThatFits(CGSize(width: availableWidth, height: .greatestFiniteMagnitude)).height + layoutMargins.bottom
+        return CGSize(width: size.width, height: max(height, 44))
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        textField.frame = convert(bounds.inset(by: layoutMargins), to: contentView)
+    }
+}

--- a/samples/NativeCatalog/ios/NativeCatalog/InstantExample/ScannerViewController.swift
+++ b/samples/NativeCatalog/ios/NativeCatalog/InstantExample/ScannerViewController.swift
@@ -1,0 +1,171 @@
+//
+//  Copyright © 2018-2020 PSPDFKit GmbH. All rights reserved.
+//
+//  THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY INTERNATIONAL COPYRIGHT LAW
+//  AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT.
+//  UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
+//  This notice may not be removed from this file.
+//
+
+import AVFoundation
+import PSPDFKitUI
+
+/// The possible results of barcode scanning.
+enum BarcodeScanResult {
+    case success(barcode: String)
+    case failure(error: String)
+}
+
+protocol ScannerViewControllerDelegate: class {
+    /// Notifies the delegate when a scanning result is obtained. This will be called on the main thread.
+    func scannerViewController(_ scannerViewController: ScannerViewController, didFinishScanningWith result: BarcodeScanResult)
+}
+
+private class BarcodeScannerView: UIView {
+
+    weak var previewLayer: AVCaptureVideoPreviewLayer?
+
+    convenience init(_ previewLayer: AVCaptureVideoPreviewLayer) {
+        self.init()
+
+        previewLayer.videoGravity = .resizeAspectFill
+        layer.addSublayer(previewLayer)
+        self.previewLayer = previewLayer
+    }
+
+    @available(iOS, deprecated: 11.0) // Hide deprecation warning for statusBarOrientation
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        guard let previewLayer = previewLayer else { return }
+        previewLayer.frame = self.layer.bounds
+        previewLayer.connection?.videoOrientation = UIApplication.shared.statusBarOrientation.convertToAVCaptureVideoOrientation()
+    }
+}
+
+/// A view controller that shows the device camera and notifies its delegate when a barcode is found.
+class ScannerViewController: UIViewController {
+    private var previewLayer: AVCaptureVideoPreviewLayer?
+    private var scannerQueue = DispatchQueue(label: "com.pspdfkit.viewer.scanner-queue", qos: .userInitiated)
+    weak var delegate: ScannerViewControllerDelegate?
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = "Scan QR Code"
+        edgesForExtendedLayout = []
+        view.backgroundColor = UIColor.black
+
+        let captureSession = AVCaptureSession()
+        let previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
+
+        scannerQueue.async { [weak self] in
+            guard let self = self else { return }
+            self.setupScanning(captureSession: captureSession)
+        }
+
+        let scannerView = BarcodeScannerView(previewLayer)
+        scannerView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(scannerView)
+
+        NSLayoutConstraint.activate([
+            scannerView.topAnchor.constraint(equalTo: view.topAnchor),
+            scannerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            scannerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scannerView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+
+        self.previewLayer = previewLayer
+        navigationController?.navigationBar.prefersLargeTitles = true
+
+        navigationItem.leftBarButtonItem = UIBarButtonItem(image: SDK.imageNamed("x"), style: .done, target: self, action: #selector(closePressed))
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        if let captureSession = previewLayer?.session, captureSession.isRunning {
+            scannerQueue.async {
+                captureSession.stopRunning()
+            }
+        }
+    }
+
+    func setupScanning(captureSession: AVCaptureSession) {
+        guard let videoCaptureDevice = AVCaptureDevice.default(for: .video),
+            let videoInput = try? AVCaptureDeviceInput(device: videoCaptureDevice) else { return }
+
+        precondition(captureSession.canAddInput(videoInput))
+        captureSession.addInput(videoInput)
+
+        // Metadata output is used to get callbacks when camera detects barcode
+        let metadataOutput = AVCaptureMetadataOutput()
+
+        if captureSession.canAddOutput(metadataOutput) {
+            captureSession.addOutput(metadataOutput)
+
+            metadataOutput.metadataObjectTypes = [.qr]
+
+            // See explanation at the top of this class to find out why this is necessary.
+            metadataOutput.perform(#selector(AVCaptureMetadataOutput.setMetadataObjectsDelegate(_:queue:)), with: self, with: scannerQueue)
+
+            metadataOutput.setMetadataObjectsDelegate(self, queue: scannerQueue)
+
+            // start running the capture session only once the setup is completed
+            captureSession.startRunning()
+        } else {
+            let errorString = "Scanning is not supported on this device."
+            self.delegate?.scannerViewController(self, didFinishScanningWith: .failure(error: errorString))
+        }
+    }
+
+    @objc func closePressed() {
+        self.dismiss(animated: true, completion: nil)
+    }
+}
+
+extension ScannerViewController: AVCaptureMetadataOutputObjectsDelegate {
+    func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
+        if let captureSession = previewLayer?.session, captureSession.isRunning {
+            captureSession.stopRunning()
+        }
+
+        guard let metadataObject = metadataObjects.first,
+            let readableObject = metadataObject as? AVMetadataMachineReadableCodeObject,
+            let stringValue = readableObject.stringValue else {
+                DispatchQueue.main.async {
+                    self.delegate?.scannerViewController(self, didFinishScanningWith: .failure(error: "Didn’t find anything to scan."))
+                }
+                return
+        }
+
+        DispatchQueue.main.async {
+            self.delegate?.scannerViewController(self, didFinishScanningWith: .success(barcode: stringValue))
+        }
+    }
+}
+
+extension UIInterfaceOrientation {
+    func convertToAVCaptureVideoOrientation() -> AVCaptureVideoOrientation {
+        switch self {
+        case .landscapeLeft:
+            return AVCaptureVideoOrientation.landscapeLeft
+        case .landscapeRight:
+            return AVCaptureVideoOrientation.landscapeRight
+        case .portraitUpsideDown:
+            return AVCaptureVideoOrientation.portraitUpsideDown
+        case .portrait, .unknown:
+            return AVCaptureVideoOrientation.portrait
+        @unknown default:
+            fatalError()
+        }
+    }
+}

--- a/samples/NativeCatalog/ios/NativeCatalog/InstantExample/UIViewController+PSCFrontmost.swift
+++ b/samples/NativeCatalog/ios/NativeCatalog/InstantExample/UIViewController+PSCFrontmost.swift
@@ -1,0 +1,19 @@
+//
+//  Copyright © 2018-2020 PSPDFKit GmbH. All rights reserved.
+//
+//  The PSPDFKit Sample applications are licensed with a modified BSD license.
+//  Please see License for details. This notice may not be removed from this file.
+//
+
+import UIKit
+
+extension UIViewController {
+    /// The frontmost presented view controller on top of the receiver.
+    var psc_frontmost: UIViewController {
+        var topController = self
+        while let presentedViewController = topController.presentedViewController {
+            topController = presentedViewController
+        }
+        return topController
+    }
+}

--- a/samples/NativeCatalog/ios/NativeCatalog/InstantExample/WebExamplesAPIClient.swift
+++ b/samples/NativeCatalog/ios/NativeCatalog/InstantExample/WebExamplesAPIClient.swift
@@ -1,0 +1,185 @@
+//
+//  Copyright © 2017-2020 PSPDFKit GmbH. All rights reserved.
+//
+//  The PSPDFKit Sample applications are licensed with a modified BSD license.
+//  Please see License for details. This notice may not be removed from this file.
+//
+
+import Foundation
+import UIKit
+
+/**
+ Interfaces with our PSPDFKit for Web examples server.
+
+ This is just networking and JSON parsing. It’s very specific our backend so not very useful as sample code.
+ In your own app you would connect to your own server backend to get Instant document identifiers and authentication tokens.
+ */
+class WebExamplesAPIClient: NSObject, URLSessionTaskDelegate {
+
+    enum Failure: Error {
+        case cancelled
+        case invalidCode
+        case internalError(underlying: Error?)
+    }
+
+    typealias APIResult = Result<InstantDocumentInfo, Error>
+    typealias CompletionHandler = (_ result: APIResult) -> Void
+
+    private lazy var session = URLSession(configuration: .default, delegate: self, delegateQueue: .main)
+    private weak var presentingViewController: UIViewController?
+
+    init(presentingViewController: UIViewController?) {
+        self.presentingViewController = presentingViewController
+        super.init()
+    }
+
+    /// Starts a new collaboration group. The completion handler may be called on a background thread.
+    func createNewSession(completion: @escaping CompletionHandler) {
+        var request = URLRequest(url: URL(string: "https://web-examples.pspdfkit.com/api/instant-landing-page")!)
+        request.httpMethod = "POST"
+
+        startDataTask(with: request, completion: completion)
+    }
+
+    /// Tries to access an existing collaboration group. The completion handler may be called on a background thread.
+    func resolveExistingSessionURL(_ url: URL, completion: @escaping CompletionHandler) {
+        var request = URLRequest(url: url)
+        request.addValue("application/vnd.instant-example+json", forHTTPHeaderField: "Accept")
+
+        startDataTask(with: request, completion: completion)
+    }
+
+    private func startDataTask(with request: URLRequest, completion: @escaping CompletionHandler) {
+        let task = session.dataTask(with: request) { data, response, error in
+            let result = self.resultFromResponse(with: data, response: response, error: error)
+            completion(result)
+        }
+        task.resume()
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPBasic, challenge.proposedCredential?.password == nil {
+            promptForHTTPBasicAuthenticationCredential(challenge: challenge) { providedCredential in
+                if let providedCredential = providedCredential {
+                    completionHandler(.useCredential, providedCredential)
+                } else {
+                    completionHandler(.cancelAuthenticationChallenge, nil)
+                }
+            }
+        } else {
+            completionHandler(.performDefaultHandling, challenge.proposedCredential)
+        }
+    }
+
+    private func promptForHTTPBasicAuthenticationCredential(challenge: URLAuthenticationChallenge, completion: @escaping (URLCredential?) -> Void) {
+        let hudWindow = presentingViewController?.view.window
+        let hudItems = StatusHUD.itemsForHUD(on: hudWindow)
+        let alert = UIAlertController(title: "Log in to \(challenge.protectionSpace.host)", message: "Your login information will be sent securely.", preferredStyle: .alert)
+
+        alert.addTextField { textField in
+            textField.placeholder = "Username"
+            textField.text = challenge.proposedCredential?.user
+        }
+
+        alert.addTextField { textField in
+            textField.isSecureTextEntry = true
+            textField.placeholder = "Password"
+        }
+
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel) { _ in
+            StatusHUD.pushItems(hudItems, on: hudWindow, animated: true) {
+                completion(nil)
+            }
+        }
+
+        let logInAction = UIAlertAction(title: "Log In", style: .default) { [unowned alert] _ in
+            guard let textFields = alert.textFields, textFields.count == 2 else {
+                StatusHUD.pushItems(hudItems, on: hudWindow, animated: true) {
+                    completion(nil)
+                }
+                return
+            }
+            let credential = URLCredential(
+                user: textFields[0].text ?? "",
+                password: textFields[1].text ?? "",
+                persistence: .permanent
+            )
+            StatusHUD.pushItems(hudItems, on: hudWindow, animated: true) {
+                completion(credential)
+            }
+        }
+
+        alert.addAction(cancelAction)
+        alert.addAction(logInAction)
+
+        StatusHUD.popItems(hudItems, animated: true) {
+            self.presentingViewController?.present(alert, animated: true)
+        }
+    }
+
+    private func resultFromResponse(with data: Data?, response: URLResponse?, error: Error?) -> APIResult {
+        if let error = error as? URLError {
+            switch error.code {
+            case .cancelled:
+                return .failure(Failure.cancelled)
+            default:
+                return .failure(Failure.internalError(underlying: error))
+            }
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            return .failure(Failure.internalError(underlying: nil))
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            if let data = data, let json = try? JSONSerialization.jsonObject(with: data) {
+                if let document = InstantDocumentInfo(json: json) {
+                    return .success(document)
+                }
+            }
+            return .failure(Failure.internalError(underlying: nil))
+        case 400:
+            return .failure(Failure.invalidCode)
+        default:
+            return .failure(Failure.internalError(underlying: nil))
+        }
+    }
+}
+
+extension WebExamplesAPIClient.Failure: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .cancelled:
+            return "The request has been cancelled."
+        case .invalidCode:
+            return "The document code is invalid."
+        case .internalError(let underlying?):
+            return "An error occurred: \(underlying)"
+        case .internalError(nil):
+            return "An internal error occurred."
+        }
+    }
+}
+
+extension StatusHUD {
+
+    fileprivate static func popItems(_ items: [StatusHUDItem]?, animated: Bool, completion: @escaping () -> Void) {
+        guard let items = items, !items.isEmpty else {
+            completion()
+            return
+        }
+        items.dropLast().forEach { $0.pop(animated: true, completion: nil) }
+        items.last!.pop(animated: animated, completion: completion)
+    }
+
+    fileprivate static func pushItems(_ items: [StatusHUDItem]?, on window: UIWindow?, animated: Bool, completion: @escaping () -> Void) {
+        guard let items = items, !items.isEmpty else {
+            completion()
+            return
+        }
+        items.dropLast().forEach { $0.push(animated: animated, on: window, completion: nil) }
+        items.last!.push(animated: animated, on: window, completion: completion)
+    }
+
+}

--- a/samples/NativeCatalog/ios/Podfile
+++ b/samples/NativeCatalog/ios/Podfile
@@ -36,6 +36,7 @@ target 'NativeCatalog' do
   
   pod 'react-native-pspdfkit', :path => '../node_modules/react-native-pspdfkit'  
   pod 'PSPDFKit', podspec:'https://customers.pspdfkit.com/cocoapods/YOUR_COCOAPODS_KEY_GOES_HERE/pspdfkit/latest.podspec'
+  pod 'Instant', podspec:'https://customers.pspdfkit.com/cocoapods/YOUR_COCOAPODS_KEY_GOES_HERE/instant/latest.podspec'
 
   target 'NativeCatalogTests' do
     inherit! :search_paths

--- a/samples/NativeCatalog/package.json
+++ b/samples/NativeCatalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NativeCatalog",
-  "version": "1.28.6",
+  "version": "1.28.7",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
# Details

In this PR, we're bridging the Instant example from native [PSPDFKit Catalog](https://pspdfkit.com/guides/ios/current/getting-started/example-projects/#pspdfcatalog) to the NativeCatalog React Native sample project.

![recording](https://user-images.githubusercontent.com/7443038/77775126-81606a80-7022-11ea-8b01-da00d31cbf07.gif)

# Acceptance Criteria

- [x] The newly added NativeCatalog example works on iOS and does not break the Android example.
- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, `samples/Catalog/package.json`, and `samples/NativeCatalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
