### PR TITLE
Update to PSPDFKit for Windows 2.6.2

### DIFF
--- a/samples/Catalog/windows/Catalog/Catalog.csproj
+++ b/samples/Catalog/windows/Catalog/Catalog.csproj
@@ -263,7 +263,7 @@
     <SDKReference Include="Microsoft.VCLibs, Version=14.0">
       <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
     </SDKReference>
-    <SDKReference Include="PSPDFKitSDK, Version=2.5.0">
+    <SDKReference Include="PSPDFKitSDK, Version=2.6.2">
       <Name>PSPDFKit for UWP</Name>
     </SDKReference>
   </ItemGroup>

--- a/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/ReactNativePSPDFKit.csproj
+++ b/windows/ReactNativePSPDFKit/ReactNativePSPDFKit/ReactNativePSPDFKit.csproj
@@ -138,7 +138,7 @@
     <SDKReference Include="Microsoft.VCLibs, Version=14.0">
       <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
     </SDKReference>
-    <SDKReference Include="PSPDFKitSDK, Version=2.5.0">
+    <SDKReference Include="PSPDFKitSDK, Version=2.6.2">
       <Name>PSPDFKit for UWP</Name>
     </SDKReference>
   </ItemGroup>


### PR DESCRIPTION
Updated 2.6.2.

Tested build and ran through a QA of all catalog examples.