### PR TITLE
Provide default fragment tag for PSPDFKitView

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ class PSPDFKitView extends React.Component {
       return (
         <RCTPSPDFKitView
           ref="pdfView"
+          fragmentTag="PSPDFKitView.FragmentTag"
           {...this.props}
           onCloseButtonPressed={onCloseButtonPressedHandler}
           onStateChanged={this._onStateChanged}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.29.4",
+  "version": "1.29.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.29.4",
+  "version": "1.29.5",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.29.4",
+  "version": "1.29.5",
   "private": true,
   "scripts": {
     "start": "react-native start",

--- a/samples/NativeCatalog/package.json
+++ b/samples/NativeCatalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NativeCatalog",
-  "version": "1.29.4",
+  "version": "1.29.5",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR adds default fragment tag for the `PSPDFKitView`. This fixes an issue that prevented `PSPDFKitView` from loading on Android.

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, `samples/Catalog/package.json`, and `samples/NativeCatalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
