### PR TITLE
Fixes issue where the last page view would be layed out incorrectly in single page mode and scroll per spread page trasition after device rotation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.29.9",
+  "version": "1.29.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.29.9",
+  "version": "1.29.10",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.29.9",
+  "version": "1.29.10",
   "private": true,
   "scripts": {
     "start": "react-native start",

--- a/samples/NativeCatalog/package.json
+++ b/samples/NativeCatalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NativeCatalog",
-  "version": "1.29.9",
+  "version": "1.29.10",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
Fixes https://github.com/PSPDFKit/PSPDFKit/issues/25653

---

# Details

## How to Reproduce:

- Modify `ConfiguredPDFViewComponent` like so:

```diff
class ConfiguredPDFViewComponent extends Component {
  render() {
    return (
      <View style={{ flex: 1 }}>
        <PSPDFKitView
          document={"PDFs/Annual Report.pdf"}
          configuration={{
            backgroundColor: processColor("lightgrey"),
            showThumbnailBar: "scrubberBar",
            showDocumentLabel: false,
            useParentNavigationBar: false,
            allowToolbarTitleChange: false,
+           pageMode: 'single',
+           pageTransition: 'scrollPerSpread'
          }}
          toolbarTitle={"Custom Title"}
          style={{ flex: 1, color: pspdfkitColor }}
        />
      </View>
    );
  }
}
```

- Go to the last page
- Rotate the device a few times

## Expected:

The last page view should always be centered.

## Actual:

The last page view will be layed out incorrectly.

<img width="1316" alt="Screen Shot 2020-09-14 at 10 55 22 AM" src="https://user-images.githubusercontent.com/7443038/93101905-d9deff00-f678-11ea-9d72-028f009f7d16.png">

# Acceptance Criteria

- [x] Fix the issue.
- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, `samples/Catalog/package.json`, and `samples/NativeCatalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
