### PR TITLE
Fix stamps not being correctly detected

### DIFF
--- a/android/src/main/java/com/pspdfkit/react/helper/ConversionHelpers.java
+++ b/android/src/main/java/com/pspdfkit/react/helper/ConversionHelpers.java
@@ -51,6 +51,9 @@ public class ConversionHelpers {
         if ("pspdfkit/text".equalsIgnoreCase(type)) {
             return EnumSet.of(AnnotationType.FREETEXT);
         }
+        if ("pspdfkit/stamp".equalsIgnoreCase(type)) {
+            return EnumSet.of(AnnotationType.STAMP);
+        }
         return EnumSet.noneOf(AnnotationType.class);
     }
 }

--- a/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFAnnotation.m
+++ b/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFAnnotation.m
@@ -54,10 +54,14 @@
     return PSPDFAnnotationTypeLine;
   } else if ([type isEqualToString:@"pspdfkit/shape/polygon"]) {
     return PSPDFAnnotationTypePolygon;
+  } else if ([type isEqualToString:@"pspdfkit/shape/polyline"]) {
+    return PSPDFAnnotationTypePolyLine;
   } else if ([type isEqualToString:@"pspdfkit/shape/rectangle"]) {
     return PSPDFAnnotationTypeSquare;
   } else if ([type isEqualToString:@"pspdfkit/text"]) {
     return PSPDFAnnotationTypeFreeText;
+  } else if ([type isEqualToString:@"pspdfkit/stamp"]) {
+    return PSPDFAnnotationTypeStamp;
   } else {
     return PSPDFAnnotationTypeUndefined;
   }


### PR DESCRIPTION
# Details

We missed a case for converting the instant stamp type to our native annotation type enum. This lead to certain functions not working with stamp annotations.

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, `samples/Catalog/package.json`, and `samples/NativeCatalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
