### PR TITLE
Fix annotation tapped events not being emitted when editing is disabled

### DIFF
--- a/android/src/main/java/com/pspdfkit/views/PdfViewDocumentListener.java
+++ b/android/src/main/java/com/pspdfkit/views/PdfViewDocumentListener.java
@@ -77,7 +77,10 @@ class PdfViewDocumentListener implements DocumentListener, AnnotationManager.OnA
     }
 
     @Override
-    public boolean onPageClick(@NonNull PdfDocument pdfDocument, int i, @Nullable MotionEvent motionEvent, @Nullable PointF pointF, @Nullable Annotation annotation) {
+    public boolean onPageClick(@NonNull PdfDocument pdfDocument, int pageIndex, @Nullable MotionEvent motionEvent, @Nullable PointF pointF, @Nullable Annotation annotation) {
+        if (annotation != null) {
+            eventDispatcher.dispatchEvent(new PdfViewAnnotationTappedEvent(parent.getId(), annotation));
+        }
         return false;
     }
 
@@ -103,7 +106,6 @@ class PdfViewDocumentListener implements DocumentListener, AnnotationManager.OnA
 
     @Override
     public boolean onPrepareAnnotationSelection(@NonNull AnnotationSelectionController annotationSelectionController, @NonNull Annotation annotation, boolean annotationCreated) {
-        eventDispatcher.dispatchEvent(new PdfViewAnnotationTappedEvent(parent.getId(), annotation));
         return !disableDefaultActionForTappedAnnotations;
     }
 


### PR DESCRIPTION

# Details

This changes how `onAnnotationTapped` events are emitted. Instead of relying on the `onPrepareAnnotationSelection` we now use the `onPageClick` which also works when annotation editing is disabled.

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, `samples/Catalog/package.json`, and `samples/NativeCatalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
