### PR TITLE
Fix issue where `disableAutomaticSaving` did not work when `useParentNavigationBar` was enabled.

### DIFF
--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -98,7 +98,15 @@ RCT_EXPORT_VIEW_PROPERTY(hideNavigationBar, BOOL)
 
 RCT_EXPORT_VIEW_PROPERTY(disableDefaultActionForTappedAnnotations, BOOL)
 
-RCT_EXPORT_VIEW_PROPERTY(disableAutomaticSaving, BOOL)
+RCT_CUSTOM_VIEW_PROPERTY(disableAutomaticSaving, BOOL, RCTPSPDFKitView) {
+  if (json) {
+    view.disableAutomaticSaving = [RCTConvert BOOL:json];
+    [view.pdfController updateConfigurationWithBuilder:^(PSPDFConfigurationBuilder *builder) {
+      // Disable autosave in the configuration.
+      builder.autosaveEnabled = !view.disableAutomaticSaving;
+    }];
+  }
+}
 
 RCT_REMAP_VIEW_PROPERTY(color, tintColor, UIColor)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.30.6",
+  "version": "1.30.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.30.6",
+  "version": "1.30.7",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.30.6",
+  "version": "1.30.7",
   "private": true,
   "scripts": {
     "start": "react-native start",

--- a/samples/NativeCatalog/package.json
+++ b/samples/NativeCatalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NativeCatalog",
-  "version": "1.30.6",
+  "version": "1.30.7",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
# Details

When disabling autosave via the `disableAutomaticSaving` prop, we also need to disable the `autosaveEnabled` configuration option. This caused an issue where autosave still occurred even after setting `disableAutomaticSaving` to true.

See Z-22960

## How to Reproduce on the main branch:

- Modify the ManualSave example and set `useParentNavigationBar` to `true`:

<details>
<summary> ManualSave </summary>

```diff
class ManualSave extends Component {
  render() {
    return (
      <View style={{ flex: 1 }}>
        <PSPDFKitView
          ref="pdfView"
          document={"PDFs/Annual Report.pdf"}
          disableAutomaticSaving={true}
          configuration={{
            backgroundColor: processColor("lightgrey"),
            showThumbnailBar: "scrollable",
+           useParentNavigationBar: true,
          }}
          style={{ flex: 1, color: pspdfkitColor }}
        />
        <View
          style={{
            flexDirection: "row",
            height: 60,
            alignItems: "center",
            padding: 10,
          }}
        >
          <View>
            <Button
              onPress={() => {
                // Manual Save
                this.refs.pdfView
                  .saveCurrentDocument()
                  .then((result) => {
                    if (result) {
                      alert("Successfully saved current document.");
                    } else {
                      alert("Failed to save current document.");
                    }
                  })
                  .catch((error) => {
                    alert(JSON.stringify(error));
                  });
              }}
              title="Save"
            />
          </View>
        </View>
      </View>
    );
  }
}
```

</details>


- Launch the Catalog and open the "Manual Save" example.
- Add any annotation.
- Go back to the examples list.
- Reopen the "Manual Save" example.

## Expected:

The newly added annotation should not have been saved.

## Actual:

The newly added annotation is saved despite the fact that `disableAutomaticSaving` was set to true.

![Kapture 2021-02-09 at 11 46 53](https://user-images.githubusercontent.com/7443038/107397354-945e1b00-6acc-11eb-9d32-2217aaf735db.gif)

# Acceptance Criteria

- [x] Fix the issue.
- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, `samples/Catalog/package.json`, and `samples/NativeCatalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/202/commits/1bf805feef2ac268743e4905d94d6d8c8f16ec59).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
