### PR TITLE
iOS Catalog Improvements

### DIFF
--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.h
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) UIBarButtonItem *closeButton;
 @property (nonatomic) BOOL disableDefaultActionForTappedAnnotations;
 @property (nonatomic) BOOL disableAutomaticSaving;
+@property (nonatomic) PSPDFPageIndex pageIndex;
 @property (nonatomic, copy, nullable) NSString *annotationAuthorName;
 @property (nonatomic, copy) RCTBubblingEventBlock onCloseButtonPressed;
 @property (nonatomic, copy) RCTBubblingEventBlock onDocumentSaved;

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -41,15 +41,24 @@ RCT_CUSTOM_VIEW_PROPERTY(document, PSPDFDocument, RCTPSPDFKitView) {
   if (json) {
     view.pdfController.document = [RCTConvert PSPDFDocument:json];
     view.pdfController.document.delegate = (id<PSPDFDocumentDelegate>)view;
-    
-    // The author name may be set before the document exists. We set it again here when the document exists.
+
+    // The following properties need to be set after the document is set.
+    // We set them again here when we're certain the document exists.
     if (view.annotationAuthorName) {
       view.pdfController.document.defaultAnnotationUsername = view.annotationAuthorName;
     }
+
+    view.pdfController.pageIndex = view.pageIndex;
   }
 }
 
-RCT_REMAP_VIEW_PROPERTY(pageIndex, pdfController.pageIndex, NSUInteger)
+RCT_CUSTOM_VIEW_PROPERTY(pageIndex, PSPDFPageIndex, RCTPSPDFKitView) {
+  if (json) {
+    PSPDFPageIndex idx = [RCTConvert NSUInteger:json];
+    view.pageIndex = idx;
+    view.pdfController.pageIndex = idx;
+  }
+}
 
 RCT_CUSTOM_VIEW_PROPERTY(configuration, PSPDFConfiguration, RCTPSPDFKitView) {
   if (json) {
@@ -357,7 +366,7 @@ RCT_EXPORT_METHOD(getRightBarButtonItemsForViewMode:(nullable NSString *)viewMod
   // Override the default font family descriptors if custom font descriptors are specified.
   NSArray *customFontFamilyDescriptors = [self customFontFamilyDescriptors];
   if (customFontFamilyDescriptors.count) {
-      fontFamilyDescriptors = customFontFamilyDescriptors;
+    fontFamilyDescriptors = customFontFamilyDescriptors;
   }
   return [super initWithFontFamilyDescriptors:fontFamilyDescriptors];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.30.17",
+  "version": "1.30.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.30.17",
+  "version": "1.30.18",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/Catalog.ios.js
+++ b/samples/Catalog/Catalog.ios.js
@@ -312,6 +312,7 @@ class ConfiguredPDFViewComponent extends Component {
             useParentNavigationBar: false,
             allowToolbarTitleChange: false,
           }}
+          leftBarButtonItems={["settingsButtonItem"]}
           toolbarTitle={"Custom Title"}
           style={{ flex: 1, color: pspdfkitColor }}
         />

--- a/samples/Catalog/README.md
+++ b/samples/Catalog/README.md
@@ -1,6 +1,6 @@
 ## Catalog
 
-The project contains a large set of code examples, which illustrate how to set up and customize PSPDFKit for various use cases. You can run the Catalog app on Android and iOS.
+The project contains a large set of sample code, which illustrates how to set up and customize PSPDFKit for various use cases. You can run the Catalog app on Android and iOS.
 
 ### Running the Catalog on Android
 
@@ -10,9 +10,9 @@ The project contains a large set of code examples, which illustrate how to set u
 - Android NDK
 - Android Build Tools 23.0.1 (React Native)
 - Android Build Tools 28.0.3 (PSPDFKit module)
-- Android Gradle plugin >= 3.4.1
-- PSPDFKit >= 6.6.0
-- react-native >= 0.63.2
+- Android Gradle plugin 3.4.1 or later.
+- PSPDFKit for Android 6.6.0 or later.
+- React Native 0.60.4.
 
 #### Getting Started
 
@@ -38,9 +38,8 @@ The project contains a large set of code examples, which illustrate how to set u
 #### Requirements
 
 - The latest [Xcode](https://developer.apple.com/xcode/).
-- PSPDFKit 10.2.1 for iOS or later
-- react-native >= 0.63.4
-- CocoaPods >= 1.10.1
+- the latest version of PSPDFKit for iOS.
+- React Native 0.60.4.
 
 #### Getting Started
 

--- a/samples/Catalog/README.md
+++ b/samples/Catalog/README.md
@@ -1,0 +1,54 @@
+## Catalog
+
+The project contains a large set of code examples, which illustrate how to set up and customize PSPDFKit for various use cases. You can run the Catalog app on Android and iOS.
+
+### Running the Catalog on Android
+
+#### Requirements
+
+- Android SDK
+- Android NDK
+- Android Build Tools 23.0.1 (React Native)
+- Android Build Tools 28.0.3 (PSPDFKit module)
+- Android Gradle plugin >= 3.4.1
+- PSPDFKit >= 6.6.0
+- react-native >= 0.63.2
+
+#### Getting Started
+
+1. Clone the repository. `git clone https://github.com/PSPDFKit/react-native.git`.
+2. Install dependencies: run `yarn install` from `samples/Catalog` directory. (Because of a [bug](https://github.com/yarnpkg/yarn/issues/2165) you may need to clean `yarn`'s cache with `yarn cache clean` before.)
+3. Update license key in `samples/Catalog/android/app/src/main/AndroidManifest.xml`:
+
+```xml
+   <application>
+      ...
+
+      <meta-data
+          android:name="pspdfkit_license_key"
+          android:value="YOUR_LICENSE_KEY_GOES_HERE"/>
+
+   </application>
+```
+
+4. Catalog app is now ready to launch. From `samples/Catalog` directory run `react-native run-android`.
+
+### Running the Catalog on iOS
+
+#### Requirements
+
+- The latest [Xcode](https://developer.apple.com/xcode/).
+- PSPDFKit 10.2.1 for iOS or later
+- react-native >= 0.63.4
+- CocoaPods >= 1.10.1
+
+#### Getting Started
+
+1. Clone the repository: `git clone https://github.com/PSPDFKit/react-native.git`.
+2. Step into your newly cloned folder: `cd react-native` and create a new `PSPDFKit` directory: `mkdir PSPDFKit`.
+3. [Download the latest version of PSPDFKit for iOS](https://customers.pspdfkit.com/download/binary/ios/latest) and mount the DMG file.
+4. Copy `PSPDFKit.xcframework` and `PSPDFKitUI.xcframework` into the `PSPDFKit` directory.
+5. Install dependencies: `yarn install` in `samples/Catalog` directory. (Because of a [bug](https://github.com/yarnpkg/yarn/issues/2165) you may need to clean `yarn`'s cache with `yarn cache clean` before.)
+6. Run the app with `react-native-cli`: `react-native run-ios`
+
+**Note:** If you get an error about `config.h` not being found check out [this blog post](https://tuntunir.blogspot.com/2018/02/react-native-fatal-error-configh-file.html) for information on how to fix it.

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.30.17",
+  "version": "1.30.18",
   "private": true,
   "scripts": {
     "start": "react-native start",

--- a/samples/Catalog/yarn.lock
+++ b/samples/Catalog/yarn.lock
@@ -5420,7 +5420,7 @@ react-native-permissions@^1.1.1:
   integrity sha512-t0Ujm177bagjUOSzhpmkSz+LqFW04HnY9TeZFavDCmV521fQvFz82aD+POXqWsAdsJVOK3umJYBNNqCjC3g0hQ==
 
 "react-native-pspdfkit@file:../..":
-  version "1.30.17"
+  version "1.30.18"
 
 react-native-qrcode-scanner@^1.2.1:
   version "1.2.1"

--- a/samples/NativeCatalog/package.json
+++ b/samples/NativeCatalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NativeCatalog",
-  "version": "1.30.17",
+  "version": "1.30.18",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/samples/NativeCatalog/yarn.lock
+++ b/samples/NativeCatalog/yarn.lock
@@ -5511,7 +5511,7 @@ react-native-gesture-handler@^1.3.0:
     prop-types "^15.7.2"
 
 "react-native-pspdfkit@file:../..":
-  version "1.30.17"
+  version "1.30.18"
 
 react-native-safe-area-view@^0.14.1:
   version "0.14.8"


### PR DESCRIPTION
# Details

This PR adds several enhancements to the iOS Catalog example project. Here are the release notes:

- Adds a README file for the Catalog example project.
- Updates the `ConfiguredPDFViewComponent` iOS example to show the settings button in navigation bar.
- Fixes issue where the `pageIndex` prop needed to be set before the `document` prop.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, `samples/Catalog/package.json`, and `samples/NativeCatalog/package.json` (see example commit:  https://github.com/PSPDFKit/react-native/pull/389/commits/ae027329b5380906fa778354945178c7e92730a4).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
