### PR TITLE
Add new “How to Open a PDF in React Native Using the Document Picker" blog post in the “Announcements” section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Windows is not currently supported, please use the previous version [1.24.9](htt
 - [Advanced Techniques for React Native UI Components](https://pspdfkit.com/blog/2018/advanced-techniques-for-react-native-ui-components/)
 - [How to Extend React Native APIs for Windows](https://pspdfkit.com/blog/2019/how-to-extend-react-native-apis-for-windows/)
 - [How to Bridge Native iOS Code to React Native](https://pspdfkit.com/blog/2020/how-to-bridge-native-ios-code-to-react-native/)
+- [How to Open a PDF in React Native Using the Document Picker](https://pspdfkit.com/blog/2021/how-to-open-a-pdf-in-react-native-using-the-document-browser/)
 
 #### PSPDFKit
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.31.2",
+  "version": "1.31.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.31.2",
+  "version": "1.31.3",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.31.2",
+  "version": "1.31.3",
   "private": true,
   "scripts": {
     "start": "react-native start",

--- a/samples/Catalog/yarn.lock
+++ b/samples/Catalog/yarn.lock
@@ -5415,7 +5415,7 @@ react-native-permissions@^1.1.1:
   integrity sha512-t0Ujm177bagjUOSzhpmkSz+LqFW04HnY9TeZFavDCmV521fQvFz82aD+POXqWsAdsJVOK3umJYBNNqCjC3g0hQ==
 
 "react-native-pspdfkit@file:../..":
-  version "1.31.2"
+  version "1.31.3"
 
 react-native-qrcode-scanner@^1.2.1:
   version "1.2.1"

--- a/samples/NativeCatalog/package.json
+++ b/samples/NativeCatalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NativeCatalog",
-  "version": "1.31.2",
+  "version": "1.31.3",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/samples/NativeCatalog/yarn.lock
+++ b/samples/NativeCatalog/yarn.lock
@@ -5506,7 +5506,7 @@ react-native-gesture-handler@^1.3.0:
     prop-types "^15.7.2"
 
 "react-native-pspdfkit@file:../..":
-  version "1.31.2"
+  version "1.31.3"
 
 react-native-safe-area-view@^0.14.1:
   version "0.14.8"


### PR DESCRIPTION
# Details

Adding newly added “How to Open a PDF in React Native Using the Document Picker” blog post and video tutorial in the “Announcements” section

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, `samples/Catalog/package.json`, `samples/Catalog/yarn.lock`, `samples/NativeCatalog/package.json`, and `samples/NativeCatalog/yarn.lock` (see example commit:  https://github.com/PSPDFKit/react-native/pull/403/commits/b32b4edd97ee9b49c51c8b932e2bf477744c2b24).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
