### PR TITLE
Make sure page index is set when showing PDF

### DIFF
--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -78,6 +78,8 @@
      [topControllerView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
      [topControllerView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
    ]];
+
+  self.pdfController.pageIndex = self.pageIndex;
 }
 
 - (void)destroyViewControllerRelationship {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.31.3",
+  "version": "1.31.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.31.3",
+  "version": "1.31.4",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.31.3",
+  "version": "1.31.4",
   "private": true,
   "scripts": {
     "start": "react-native start",

--- a/samples/Catalog/yarn.lock
+++ b/samples/Catalog/yarn.lock
@@ -5415,7 +5415,7 @@ react-native-permissions@^1.1.1:
   integrity sha512-t0Ujm177bagjUOSzhpmkSz+LqFW04HnY9TeZFavDCmV521fQvFz82aD+POXqWsAdsJVOK3umJYBNNqCjC3g0hQ==
 
 "react-native-pspdfkit@file:../..":
-  version "1.31.3"
+  version "1.31.4"
 
 react-native-qrcode-scanner@^1.2.1:
   version "1.2.1"

--- a/samples/NativeCatalog/package.json
+++ b/samples/NativeCatalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NativeCatalog",
-  "version": "1.31.3",
+  "version": "1.31.4",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/samples/NativeCatalog/yarn.lock
+++ b/samples/NativeCatalog/yarn.lock
@@ -5506,7 +5506,7 @@ react-native-gesture-handler@^1.3.0:
     prop-types "^15.7.2"
 
 "react-native-pspdfkit@file:../..":
-  version "1.31.3"
+  version "1.31.4"
 
 react-native-safe-area-view@^0.14.1:
   version "0.14.8"


### PR DESCRIPTION
# Details

Z#25584

When using (vertical) continuous page transition, there was an issue where the set page index was not correctly set on the PDF controller, before it was shown.
Now we make sure to properly communicate the page index as soon as the PDF controller is shown.

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, `samples/Catalog/package.json`, `samples/Catalog/yarn.lock`, `samples/NativeCatalog/package.json`, and `samples/NativeCatalog/yarn.lock` (see example commit:  https://github.com/PSPDFKit/react-native/pull/403/commits/b32b4edd97ee9b49c51c8b932e2bf477744c2b24).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
