### PR TITLE
Upgrade to PSPDFKit 7 for Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,7 +15,7 @@
  *   Contains gradle configuration constants
  */
 ext {
-    PSPDFKIT_VERSION = '6.6.2'
+    PSPDFKIT_VERSION = '7.0.0'
 }
 
 buildscript {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ android {
     buildToolsVersion "28.0.3"
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.31.6",
+  "version": "1.32.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pspdfkit",
-  "version": "1.31.6",
+  "version": "1.32.0",
   "description": "A React Native module for the PSPDFKit library.",
   "keywords": [
     "react native",

--- a/samples/Catalog/README.md
+++ b/samples/Catalog/README.md
@@ -38,7 +38,7 @@ The project contains a large set of sample code, which illustrates how to set up
 6. Step into the Catalog project's directory: `cd /samples/Catalog`
 7. Install dependencies: `yarn install` in `samples/Catalog` directory. (Because of a [bug](https://github.com/yarnpkg/yarn/issues/2165) you may need to clean `yarn`'s cache with `yarn cache clean` before.)
 8. Start the Metro bundler by running `react-native start`
-9. Run the app with `react-native-cli`: `react-native run-ios`
+9. Run the app with `react-native-cli`: `react-native run-ios --simulator="iPad Pro (12.9-inch) (5th generation)"`
 
 ### Troubleshooting
 

--- a/samples/Catalog/android/app/build.gradle
+++ b/samples/Catalog/android/app/build.gradle
@@ -117,7 +117,7 @@ android {
     defaultConfig {
         applicationId "com.pspdfkit.react.catalog"
         multiDexEnabled true
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"

--- a/samples/Catalog/package.json
+++ b/samples/Catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Catalog",
-  "version": "1.31.6",
+  "version": "1.32.0",
   "private": true,
   "scripts": {
     "start": "react-native start",

--- a/samples/Catalog/yarn.lock
+++ b/samples/Catalog/yarn.lock
@@ -5415,7 +5415,7 @@ react-native-permissions@^1.1.1:
   integrity sha512-t0Ujm177bagjUOSzhpmkSz+LqFW04HnY9TeZFavDCmV521fQvFz82aD+POXqWsAdsJVOK3umJYBNNqCjC3g0hQ==
 
 "react-native-pspdfkit@file:../..":
-  version "1.31.6"
+  version "1.32.0"
 
 react-native-qrcode-scanner@^1.2.1:
   version "1.2.1"

--- a/samples/NativeCatalog/android/build.gradle
+++ b/samples/NativeCatalog/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "28.0.3"
-        minSdkVersion = 19
+        minSdkVersion = 21
         compileSdkVersion = 28
         targetSdkVersion = 28
     }

--- a/samples/NativeCatalog/package.json
+++ b/samples/NativeCatalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NativeCatalog",
-  "version": "1.31.6",
+  "version": "1.32.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/samples/NativeCatalog/yarn.lock
+++ b/samples/NativeCatalog/yarn.lock
@@ -5506,7 +5506,7 @@ react-native-gesture-handler@^1.3.0:
     prop-types "^15.7.2"
 
 "react-native-pspdfkit@file:../..":
-  version "1.31.6"
+  version "1.32.0"
 
 react-native-safe-area-view@^0.14.1:
   version "0.14.8"


### PR DESCRIPTION
# Details
* Change `PSPDFKIT_VERSION` to Android 7

# Acceptance Criteria

- [x] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, `samples/Catalog/package.json`, `samples/Catalog/yarn.lock`, `samples/NativeCatalog/package.json`, and `samples/NativeCatalog/yarn.lock` (see example commit:  https://github.com/PSPDFKit/react-native/pull/403/commits/b32b4edd97ee9b49c51c8b932e2bf477744c2b24).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
