### PR TITLE
Disable PDF document interaction

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,6 +143,30 @@ class PSPDFKitView extends React.Component {
   };
 
   /**
+   * Enable all interaction with the document
+   */
+  enableDocumentInteraction = function () {
+    console.log('enableDocumentInteraction');
+      if (Platform.OS === 'ios') {
+          return NativeModules.PSPDFKitViewManager.enableDocumentInteraction(
+          findNodeHandle(this.refs.pdfView),
+        );
+      }
+    };
+
+  /**
+   * Disable all interaction with the document
+   */
+  disableDocumentInteraction = function () {
+    console.log('disableDocumentInteraction');
+      if (Platform.OS === 'ios') {
+        return NativeModules.PSPDFKitViewManager.disableDocumentInteraction(
+        findNodeHandle(this.refs.pdfView),
+      );
+    }
+  };
+
+  /**
    * Saves the currently opened document.
    *
    * Returns a promise resolving to true if the document was saved, and false otherwise.

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.h
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.h
@@ -61,6 +61,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray <NSString *> *)getLeftBarButtonItemsForViewMode:(NSString *)viewMode;
 - (NSArray <NSString *> *)getRightBarButtonItemsForViewMode:(NSString *)viewMode;
 
+/// Document interaction
+- (BOOL)enableDocumentInteraction;
+- (BOOL)disableDocumentInteraction;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/RCTPSPDFKit/RCTPSPDFKitView.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitView.m
@@ -19,15 +19,24 @@
 
 @property (nonatomic, strong) UIScrollView *scrollView;
 @property (nonatomic, strong) UIScrollView *zoomView;
+@property (readonly, assign) BOOL documentInteractionEnabled;
 
 @end
 
 @implementation OverrideScrolling
 
+- (id)init {
+    if (self = [super init])  {
+        _documentInteractionEnabled = YES;
+    }
+    return self;
+}
+
 - (BOOL)enableInteraction:(BOOL)enable {
     if (_scrollView != nil && _zoomView != nil) {
         _scrollView.panGestureRecognizer.enabled = enable;
         _zoomView.panGestureRecognizer.enabled = enable;
+        _documentInteractionEnabled = enable;
         return YES;
     }
     return NO;
@@ -64,6 +73,14 @@
     _pdfController.annotationToolbarController.delegate = self;
       
     _overrideScrolling = [OverrideScrolling new];
+      
+      NSMutableArray *buttonItems = [NSMutableArray arrayWithArray:_pdfController.navigationItem.rightBarButtonItems];
+      // ** If using a custom image **
+      // UIBarButtonItem *newItem = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"myImage.png"] style:UIBarButtonItemStylePlain target:self action:@selector(buttonPressed)];
+      // ** If using a custom image **
+      UIBarButtonItem *newItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCompose target:self action:@selector(customButtonPressed)];
+      [buttonItems addObject:newItem];
+      [_pdfController.navigationItem setRightBarButtonItems:buttonItems forViewMode:PSPDFViewModeDocument animated:NO];
     
     // Store the closeButton's target and selector in order to call it later.
     _closeButtonAttributes = @{@"target" : _pdfController.closeButtonItem.target,
@@ -188,6 +205,10 @@
 
 - (BOOL)disableDocumentInteraction {
     return [self enableDocumentInteraction:NO];
+}
+
+- (void)customButtonPressed {
+    [self enableDocumentInteraction:![_overrideScrolling documentInteractionEnabled]];
 }
 
 // MARK: - PSPDFDocumentDelegate

--- a/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
+++ b/ios/RCTPSPDFKit/RCTPSPDFKitViewManager.m
@@ -228,6 +228,30 @@ RCT_EXPORT_METHOD(exitCurrentlyActiveMode:(nonnull NSNumber *)reactTag resolver:
   });
 }
 
+RCT_EXPORT_METHOD(enableDocumentInteraction:(nonnull NSNumber *)reactTag resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];
+    BOOL success = [component enableDocumentInteraction];
+    if (success) {
+      resolve(@(success));
+    } else {
+      reject(@"error", @"Failed to enable document interaction.", nil);
+    }
+  });
+}
+
+RCT_EXPORT_METHOD(disableDocumentInteraction:(nonnull NSNumber *)reactTag resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];
+    BOOL success = [component disableDocumentInteraction];
+    if (success) {
+      resolve(@(success));
+    } else {
+      reject(@"error", @"Failed to disable document interaction.", nil);
+    }
+  });
+}
+
 RCT_EXPORT_METHOD(saveCurrentDocument:(nonnull NSNumber *)reactTag resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   dispatch_async(dispatch_get_main_queue(), ^{
     RCTPSPDFKitView *component = (RCTPSPDFKitView *)[self.bridge.uiManager viewForReactTag:reactTag];


### PR DESCRIPTION
Example implementation to disable or enable all document interaction.

**Usage:**
```
await this.pdfRef.current.disableDocumentInteraction();
```
**or**
```
await this.pdfRef.current.enableDocumentInteraction();
```