### PR TITLE
Fixed RCTConvert+PSPDFDocument.m parseURL function to be able to handle custom remote sources.

### DIFF
--- a/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFDocument.m
+++ b/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFDocument.m
@@ -28,7 +28,11 @@
 + (NSURL*)parseURL:(NSString*)urlString {
     NSURL* url;
 
-    if ([urlString hasPrefix: @"/"] || [urlString containsString: @"file:/"]) {
+    if ([urlString hasPrefix: @"http"]) {
+        url = [NSURL URLWithString:urlString];
+    }
+
+    if (url == nil && ([urlString hasPrefix: @"/"] || [urlString containsString: @"file:/"])) {
         if ([urlString hasPrefix:@"file:///"]) {
             urlString = [urlString substringFromIndex:7];
         }


### PR DESCRIPTION
# Details

Passing a URL to the `document` prop causes an error on iOS. The reason is how the `parseURL` function handles incoming strings. If you pass a link, the function will try to find a local resource (which is not correct) and cause an error as a result.

<img src="https://github.com/PSPDFKit/react-native/assets/5526543/1c789ec4-7379-4cbb-9373-eee527a39982" data-canonical-src="https://github.com/PSPDFKit/react-native/assets/5526543/1c789ec4-7379-4cbb-9373-eee527a39982" width="200" />

## Dependencies

react-native: 0.72.12
react-native-pspdfkit: 2.9.1
PSPDFKit: 13.3.3
PSPDFKit/Core: 13.3.3

## Steps to reproduce

```
    <PSPDFKitView
      document={'https://pspdfkit.com/demo/examples/document-security/prevent-pdf-print-or-download/example.pdf'}
      configuration={{
        pageTransition: 'scrollContinuous',
        scrollDirection: 'vertical',
        documentLabelEnabled: true,
      }}
      style={{flex: 1, color: '#267AD4'}}
    />
```

 or

```
    PSPDFKit.present('https://pspdfkit.com/demo/examples/document-security/prevent-pdf-print-or-download/example.pdf', {
      showThumbnailBar: 'scrollable',
      enableInstantComments: true,
    });
```

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, `samples/Catalog/package.json`, `samples/Catalog/yarn.lock`, `samples/NativeCatalog/package.json`, and `samples/NativeCatalog/yarn.lock` (see example commit: https://github.com/PSPDFKit/react-native/pull/403/commits/b32b4edd97ee9b49c51c8b932e2bf477744c2b24).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
