### PR TITLE
Add Signature props:  signatureCreationModes and signatureColorOptions

### DIFF
--- a/android/src/main/java/com/pspdfkit/react/ConfigurationAdapter.java
+++ b/android/src/main/java/com/pspdfkit/react/ConfigurationAdapter.java
@@ -15,7 +15,6 @@ package com.pspdfkit.react;
 
 import android.content.Context;
 import android.graphics.Color;
-import android.os.Parcel;
 import android.util.Log;
 
 import androidx.annotation.NonNull;

--- a/android/src/main/java/com/pspdfkit/react/ConfigurationAdapter.java
+++ b/android/src/main/java/com/pspdfkit/react/ConfigurationAdapter.java
@@ -14,6 +14,8 @@
 package com.pspdfkit.react;
 
 import android.content.Context;
+import android.graphics.Color;
+import android.os.Parcel;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -31,9 +33,11 @@ import com.pspdfkit.configuration.page.PageLayoutMode;
 import com.pspdfkit.configuration.page.PageScrollDirection;
 import com.pspdfkit.configuration.page.PageScrollMode;
 import com.pspdfkit.configuration.sharing.ShareFeatures;
+import com.pspdfkit.configuration.signatures.SignatureColorOptions;
 import com.pspdfkit.configuration.signatures.SignatureCreationMode;
 import com.pspdfkit.configuration.signatures.SignatureSavingStrategy;
 import com.pspdfkit.preferences.PSPDFKitPreferences;
+import com.pspdfkit.react.helper.ColorHelper;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -117,7 +121,8 @@ public class ConfigurationAdapter {
 
     // Signature presentation options
     private static final String SIGNATURE_CREATION_MODES = "signatureCreationModes";
-    
+    private static final String SIGNATURE_COLOR_OPTIONS = "signatureColorOptions";
+
     // Deprecated Options
     /**
      * @deprecated This key word was deprecated with PSPDFKit for React Native 2.1.
@@ -329,6 +334,10 @@ public class ConfigurationAdapter {
             key = getKeyOrNull(configuration, SIGNATURE_CREATION_MODES);
             if (key != null) {
                 configureSignatureCreationModes(configuration.getArray(key));
+            }
+            key = getKeyOrNull(configuration, SIGNATURE_COLOR_OPTIONS);
+            if (key != null) {
+                configureSignatureColorOptions(context, configuration.getArray(key));
             }
         }
     }
@@ -733,6 +742,43 @@ public class ConfigurationAdapter {
           }
         }
         configuration.signatureCreationModes(parsedTypes);
+    }
+
+    private void configureSignatureColorOptions(final Context context, @Nullable final ReadableArray signatureCreationColors) {
+      if (signatureCreationColors == null) {
+          return;
+      }
+
+      List<Object> sigCreationColors = signatureCreationColors.toArrayList();
+
+      SignatureColorOptions defaultColors = SignatureColorOptions.fromDefaults();
+      int[] configuredColors = new int[] { defaultColors.option1(context),
+        defaultColors.option2(context), defaultColors.option3(context) };
+
+      int i = 0;
+      for (Object rgbaColorOrName : sigCreationColors) {
+        // only 3 colors are supported
+        if (i == 3) break;
+
+        String color = rgbaColorOrName.toString();
+
+        // attempt to resolve colors, if no match
+        // we'll use the default value at this index
+        if (color.contains("rgb(")) {
+          configuredColors[i] = ColorHelper.rgb(color);
+        }
+        else {
+          // hex or named colors
+          configuredColors[i] = Color.parseColor(color);
+        }
+
+        i++;
+      }
+
+      configuration.signatureColorOptions(SignatureColorOptions.fromColorInt(
+        configuredColors[0],
+        configuredColors[1],
+        configuredColors[2]));
     }
 
     public PdfActivityConfiguration build() {

--- a/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFConfiguration.m
+++ b/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFConfiguration.m
@@ -574,7 +574,6 @@ RCT_MULTI_ENUM_CONVERTER(PSPDFDocumentSharingPagesOptions,
     NSMutableArray *signatureCreationColors = [NSMutableArray array];
     [configuration.signatureCreationConfiguration.colors enumerateObjectsUsingBlock:^(UIColor * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
         
-        // remove alpha
         NSString *hexColor = [NSString stringWithFormat:@"#%02lX", [obj hex]];
         
         [signatureCreationColors addObject:hexColor];

--- a/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFConfiguration.m
+++ b/ios/RCTPSPDFKit/Converters/RCTConvert+PSPDFConfiguration.m
@@ -132,6 +132,10 @@
 #define BookmarkSortOrderMap @{@"custom" : @(PSPDFBookmarkManagerSortOrderCustom), \
                                @"pageBased" : @(PSPDFBookmarkManagerSortOrderPageBased)} \
 
+#define SignatureCreationModeMap @{@"draw": @(PSPDFSignatureCreationModeDraw), \
+                                   @"image": @(PSPDFSignatureCreationModeImage), \
+                                   @"type": @(PSPDFSignatureCreationModeType)} \
+
 @implementation RCTConvert (PSPDFConfiguration)
 
 + (PSPDFConfiguration *)PSPDFConfiguration:(id)json {
@@ -563,6 +567,10 @@ RCT_MULTI_ENUM_CONVERTER(PSPDFDocumentSharingPagesOptions,
     [convertedConfiguration setObject:[RCTConvert findKeyForValue:configuration.bookmarkSortOrder
                                                      inDictionary:BookmarkSortOrderMap] forKey:@"iOSBookmarkSortOrder"];
     
+    [convertedConfiguration setObject:[RCTConvert findKeysForValues:[NSSet setWithArray:configuration.signatureCreationConfiguration.availableModes]
+                                                       inDictionary:SignatureCreationModeMap]
+                               forKey:@"signatureCreationModes"];
+    
     return convertedConfiguration;
 }
 
@@ -694,6 +702,8 @@ RCT_MULTI_ENUM_CONVERTER(PSPDFDocumentSharingPagesOptions,
     self.editableAnnotationTypes = [editableTypes copy];
   }
 
+  [self setRCTSignatureCreationConfiguration:dictionary];
+
   // Deprecated Options
 
   // Use `scrollDirection` instead.
@@ -737,6 +747,29 @@ RCT_MULTI_ENUM_CONVERTER(PSPDFDocumentSharingPagesOptions,
   }];
 
   self.sharingConfigurations = rnSharingConfigurations;
+}
+
+- (void)setRCTSignatureCreationConfiguration:(NSDictionary *)configuration {
+    PSPDFSignatureCreationConfigurationBuilder *builder = [PSPDFSignatureCreationConfigurationBuilder alloc];
+    
+    // important: set all default values
+    [builder reset];
+    
+    if (configuration[@"signatureCreationModes"]) {
+        NSSet *selectedModes = [NSSet setWithArray:[RCTConvert NSArray:configuration[@"signatureCreationModes"]]];
+        
+        NSMutableArray *mappedValues = [NSMutableArray new];
+        for (NSString* signatureCreationModeString in selectedModes) {
+            NSNumber *value = [SignatureCreationModeMap valueForKey:signatureCreationModeString];
+            if (value != nil) {
+                [mappedValues addObject:value];
+            }
+        }
+        
+        builder.availableModes = mappedValues;
+    }
+    
+    self.signatureCreationConfiguration = [builder build];
 }
 
 @end

--- a/ios/RCTPSPDFKit/UIColor.swift
+++ b/ios/RCTPSPDFKit/UIColor.swift
@@ -11,7 +11,7 @@
 import UIKit
 
 extension UIColor {
-    public convenience init?(hexString: String) {
+    @objc public convenience init?(hexString: String) {
         let r, g, b, a: CGFloat
 
         if hexString.hasPrefix("#") {
@@ -51,7 +51,7 @@ extension UIColor {
     }
 
 
-    public static func colorFromName(_ name: String) -> UIColor? {
+    @objc public static func colorFromName(_ name: String) -> UIColor? {
         let selector = Selector("\(name)Color")
         if UIColor.self.responds(to: selector) {
             let color = UIColor.self.perform(selector).takeUnretainedValue()
@@ -61,7 +61,7 @@ extension UIColor {
         return nil
     }
 
-    public static func rgb(_ colorValue: String) -> UIColor? {
+    @objc public static func rgb(_ colorValue: String) -> UIColor? {
         let colorsComponentString: String = colorValue.replacingOccurrences(of: "rgb(", with: "").replacingOccurrences(of: ")", with: "").replacingOccurrences(of: " ", with: "")
         let colorComponents = colorsComponentString.components(separatedBy: ",")
 
@@ -101,6 +101,14 @@ extension UIColor {
         getRed(&red, green: &green, blue: &blue, alpha: &alpha)
         return Int(alpha * 255) << 24
              + Int(red   * 255) << 16
+             + Int(green * 255) << 8
+             + Int(blue  * 255)
+    }
+
+    @objc public var hex: Int {
+        var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
+        getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return Int(red   * 255) << 16
              + Int(green * 255) << 8
              + Int(blue  * 255)
     }

--- a/src/configuration/PDFConfiguration.ts
+++ b/src/configuration/PDFConfiguration.ts
@@ -101,6 +101,7 @@ import { MeasurementValueConfiguration } from './../measurements/Measurements';
  * @property { PDFConfiguration.BooleanType } [syncAnnotations] Indicates whether document annotations should be synced with the Instant server.
  * @property { Measurements.MeasurementValueConfiguration[] } [measurementValueConfigurations] The array of ```MeasurementValueConfiguration``` objects that should be applied to the document.
  * @property { PDFConfiguration.RemoteDocumentConfiguration } [remoteDocumentConfiguration] The configuration when downloading a document from a remote URL.
+ * @property { PDFConfiguration.SignatureCreationModes[] } [signatureCreationModes] The signature creation modes that should be available in the signature picker.
  */
 
 export class PDFConfiguration {
@@ -475,6 +476,11 @@ export class PDFConfiguration {
      * The configuration when downloading a document from a remote URL.
      */
     remoteDocumentConfiguration?: RemoteDocumentConfiguration;
+
+    /**
+     * The signature creation modes that should be available in the signature picker.
+     */
+    signatureCreationModes?: PDFConfiguration.SignatureCreationModes[];
 }
 
 export namespace PDFConfiguration {
@@ -1000,6 +1006,27 @@ export namespace PDFConfiguration {
         */
         PAGE_BASED: 'pageBased'
     } as const;
+
+    /**
+     * The possible ways in which the user can input their signature.
+     * @readonly
+     * @enum {string} SignatureCreationModes
+     */
+    export const SignatureCreationModes = {
+      /**
+       * The user draws their signature. For example using a finger or stylus.
+       */
+      DRAW: 'draw',
+      /**
+       * The user selects an existing image of their signature from their photo library or files, or takes
+       * a photo of their signature written on a piece of paper.
+       */
+      IMAGE: 'image',
+      /**
+       * The user types their name and selects a style for their signature from a small number of fonts.
+       */
+      TYPE: 'type'
+    } as const;
     
     export type BooleanType = ValueOf<typeof BooleanType>;
     export type ScrollDirection = ValueOf<typeof ScrollDirection>;
@@ -1023,6 +1050,7 @@ export namespace PDFConfiguration {
     export type IOSLinkAction = ValueOf<typeof IOSLinkAction>;
     export type IOSDrawCreateMode = ValueOf<typeof IOSDrawCreateMode>;
     export type IOSBookmarkSortOrder = ValueOf<typeof IOSBookmarkSortOrder>;
+    export type SignatureCreationModes = ValueOf<typeof SignatureCreationModes>;
 }
 
 /**

--- a/src/configuration/PDFConfiguration.ts
+++ b/src/configuration/PDFConfiguration.ts
@@ -102,7 +102,8 @@ import { MeasurementValueConfiguration } from './../measurements/Measurements';
  * @property { Measurements.MeasurementValueConfiguration[] } [measurementValueConfigurations] The array of ```MeasurementValueConfiguration``` objects that should be applied to the document.
  * @property { PDFConfiguration.RemoteDocumentConfiguration } [remoteDocumentConfiguration] The configuration when downloading a document from a remote URL.
  * @property { PDFConfiguration.SignatureCreationModes[] } [signatureCreationModes] The signature creation modes that should be available in the signature picker.
- */
+ * @property { PDFConfiguration.SignatureColorOptions[] } [signatureColorOptions] The color options that should be available in the signature picker, max of 3 colors are supported. If all 3 colors are not provided, defaults will be used in their place.
+*/
 
 export class PDFConfiguration {
 
@@ -481,6 +482,11 @@ export class PDFConfiguration {
      * The signature creation modes that should be available in the signature picker.
      */
     signatureCreationModes?: PDFConfiguration.SignatureCreationModes[];
+
+    /**
+     * The signature color options that should be available in the signature picker, max of 3 colors are supported. If all 3 colors are not provided, defaults will be used in their place.
+     */
+    signatureColorOptions?: PDFConfiguration.SignatureColorOptions[];
 }
 
 export namespace PDFConfiguration {
@@ -1027,6 +1033,16 @@ export namespace PDFConfiguration {
        */
       TYPE: 'type'
     } as const;
+
+    /**
+     * Color defined by a hex string of RGB values.
+     */
+    export type HexColor = `#${string}`;
+
+    /**
+     * Color defined by RGB values.
+     */
+    export type RGBColor = `rgb(${number},${number},${number})`;
     
     export type BooleanType = ValueOf<typeof BooleanType>;
     export type ScrollDirection = ValueOf<typeof ScrollDirection>;
@@ -1051,6 +1067,7 @@ export namespace PDFConfiguration {
     export type IOSDrawCreateMode = ValueOf<typeof IOSDrawCreateMode>;
     export type IOSBookmarkSortOrder = ValueOf<typeof IOSBookmarkSortOrder>;
     export type SignatureCreationModes = ValueOf<typeof SignatureCreationModes>;
+    export type SignatureColorOptions = HexColor | RGBColor | string;
 }
 
 /**


### PR DESCRIPTION
# Details
Provide two new props to the `PSPDFKitView` component.  This allows for further customization of the component to select acceptable signature modes and colors:

```jsx
import PSPDFKitView, { PDFConfiguration } from "react-native-pspdfkit";

<PSPDFKitView
  configuration={{
    signatureCreationModes: [
        PDFConfiguration.SignatureCreationModes.DRAW, 
        PDFConfiguration.SignatureCreationModes.IMAGE,
        PDFConfiguration.SignatureCreationModes.TYPE
    ],
    signatureColorOptions: [
        "black",
        "#876543",
        "rgb(127, 81, 202)"
    ]
  }}
/>
```

Implemented both iOS and Android backings

# Acceptance Criteria

- [ ] When approved, right before merging, rebase with master and increment the package version in `package.json`, `package-lock.json`, `samples/Catalog/package.json`, `samples/Catalog/yarn.lock`, `samples/NativeCatalog/package.json`, and `samples/NativeCatalog/yarn.lock` (see example commit: https://github.com/PSPDFKit/react-native/pull/403/commits/b32b4edd97ee9b49c51c8b932e2bf477744c2b24).
- [ ] Create a new release (and tag) with the new package version (see https://github.com/PSPDFKit/react-native/releases).
